### PR TITLE
refactor: add `get_versions` method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: seed-isort-config
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.8.0
     hooks:
       - id: isort
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Set
 
 import vvm  # type: ignore
 from ape.api.compiler import CompilerAPI
@@ -34,6 +34,18 @@ class VyperCompiler(CompilerAPI):
     @property
     def name(self) -> str:
         return "vyper"
+
+    def get_versions(self, all_paths: List[Path]) -> Set[str]:
+        versions = set()
+        for path in all_paths:
+            source = path.read_text()
+
+            # Make sure we have the compiler available to compile this
+            version_spec = get_pragma_spec(source)
+            if version_spec:
+                versions.add(str(version_spec.select(self.available_versions)))
+
+        return versions
 
     @cached_property
     def package_version(self) -> Optional[Version]:


### PR DESCRIPTION
Needed for https://github.com/ApeWorX/ape/pull/41.

Example usage:

```
$ ape console
In [1]: project.compilers.registered_compilers['.vy'].get_versions(project.sources)
Out[1]: {'0.2.11'}
```