### PR TITLE
fix: preserve compiler error

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 import vvm  # type: ignore
-
 from ape.api import ConfigDict
 from ape.api.compiler import CompilerAPI
 from ape.types import ABI, Bytecode, ContractType
@@ -42,7 +41,7 @@ def get_pragma_spec(source: str) -> Optional[NpmSpec]:
 
 
 class VyperCompiler(CompilerAPI):
-    config: ConfigDict
+    config: ConfigDict = ConfigDict()
 
     @property
     def name(self) -> str:

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -99,7 +99,7 @@ class VyperCompiler(CompilerAPI):
                     if vyper_version:
                         _install_vyper(vyper_version)
                     else:
-                        raise VyperInstallError("No available version to install.") from err
+                        raise VyperInstallError("No available version to install.")
                 else:
                     vyper_version = pragma_spec.select(self.installed_versions)
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 import vvm  # type: ignore
+
+from ape.api import ConfigDict
 from ape.api.compiler import CompilerAPI
 from ape.types import ABI, Bytecode, ContractType
 from ape.utils import cached_property
@@ -40,6 +42,8 @@ def get_pragma_spec(source: str) -> Optional[NpmSpec]:
 
 
 class VyperCompiler(CompilerAPI):
+    config: ConfigDict
+
     @property
     def name(self) -> str:
         return "vyper"

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -4,23 +4,18 @@ from typing import List, Optional, Set
 
 import vvm  # type: ignore
 from ape.api.compiler import CompilerAPI
-from ape.exceptions import CompilerError
 from ape.types import ABI, Bytecode, ContractType
 from ape.utils import cached_property
 from semantic_version import NpmSpec, Version  # type: ignore
 
+from .exceptions import VyperCompileError, VyperInstallError
 
-class VyperInstallError(CompilerError):
-    """
-    An error raised when compiling with the ape-vyper plugin
-    and you don't yet have vyper installed and it fails
-    when trying to install it.
-    """
 
-    def __init__(self, vyper_version):
-        message = f"Unable to install Vyper version: {vyper_version}"
-        self.message = message
-        super().__init__(message)
+def _install_vyper(version: Version):
+    try:
+        vvm.install_vyper(version, show_progress=True)
+    except Exception as err:
+        raise VyperInstallError(f"Unable to install Vyper version: '{version}'.") from err
 
 
 def get_pragma_spec(source: str) -> Optional[NpmSpec]:
@@ -102,22 +97,16 @@ class VyperCompiler(CompilerAPI):
                 if pragma_spec is not pragma_spec.select(self.installed_versions):
                     vyper_version = pragma_spec.select(self.available_versions)
                     if vyper_version:
-                        try:
-                            vvm.install_vyper(vyper_version, show_progress=True)
-                        except Exception as err:
-                            raise VyperInstallError(vyper_version) from err
+                        _install_vyper(vyper_version)
                     else:
-                        raise Exception("No available version to install")
+                        raise VyperInstallError("No available version to install.") from err
                 else:
                     vyper_version = pragma_spec.select(self.installed_versions)
 
             else:
                 if not self.installed_versions:
                     vyper_version = max(self.available_versions)
-                    try:
-                        vvm.install_vyper(vyper_version, show_progress=True)
-                    except Exception as err:
-                        raise VyperInstallError(vyper_version) from err
+                    _install_vyper(vyper_version)
                 else:
                     vyper_version = max(self.installed_versions)
             try:
@@ -126,11 +115,7 @@ class VyperCompiler(CompilerAPI):
                     vyper_version=vyper_version,
                 )["<stdin>"]
             except Exception as err:
-                new_err = VyperInstallError(vyper_version)
-                if hasattr(err, "stderr_data"):
-                    new_err.message += f"\n\t{err.stderr_data}"  # type: ignore
-
-                raise new_err from err
+                raise VyperCompileError(err) from err
 
             contract_types.append(
                 ContractType(

--- a/ape_vyper/exceptions.py
+++ b/ape_vyper/exceptions.py
@@ -1,0 +1,22 @@
+from ape.exceptions import CompilerError
+
+
+class VyperInstallError(CompilerError):
+    """
+    An error raised failing to install Vyper.
+    """
+
+
+class VyperCompileError(CompilerError):
+    """
+    A compiler-specific error in Vyper.
+    """
+
+    def __init__(self, err: Exception):
+        if hasattr(err, "stderr_data"):
+            message = err.stderr_data  # type: ignore
+        else:
+            message = str(err)
+
+        self.message = message
+        super().__init__(message)

--- a/ape_vyper/exceptions.py
+++ b/ape_vyper/exceptions.py
@@ -13,6 +13,7 @@ class VyperCompileError(CompilerError):
     """
 
     def __init__(self, err: Exception):
+        self.base_err = err
         if hasattr(err, "stderr_data"):
             message = err.stderr_data  # type: ignore
         else:

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a29",
+        "eth-ape>=0.1.0a31",
         "tqdm>=4.60.0,<5.0",
         "vvm>=0.1.0,<0.2.0",
     ],
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     extras_require=extras_require,
     py_modules=["ape_vyper"],
     license="Apache-2.0",

--- a/tests/contracts/failing_contracts/contract_undeclared_variable.vy
+++ b/tests/contracts/failing_contracts/contract_undeclared_variable.vy
@@ -1,4 +1,6 @@
+# @version 0.2.8
 
 @external
 def foo1() -> bool:
+    hello = world
     return True

--- a/tests/contracts/failing_contracts/contract_unknown_pragma.vy
+++ b/tests/contracts/failing_contracts/contract_unknown_pragma.vy
@@ -1,7 +1,5 @@
-# @version 0.2.8
+# @version 14021.2222.8
 
 @external
 def foo1() -> bool:
-    hello = world
     return True
-

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -3,4 +3,3 @@
 @external
 def foo1() -> bool:
     return True
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,17 +1,51 @@
 from pathlib import Path
+from typing import List
 
 import pytest  # type: ignore
+from vvm.exceptions import VyperError  # type: ignore
 
-PASSING_CONTRACTS_FOLDER = Path(__file__).parent / "contracts" / "passing_contracts"
-FAILING_CONTRACTS_FOLDER = Path(__file__).parent / "contracts" / "failing_contracts"
+from ape_vyper.exceptions import VyperCompileError, VyperInstallError
+
+BASE_CONTRACTS_PATH = Path(__file__).parent / "contracts"
 
 
-@pytest.mark.parametrize("path", PASSING_CONTRACTS_FOLDER.glob("*.vy"))
-def test_pass(path, compiler):
+def contract_test_cases(passing: bool) -> List[str]:
+    """
+    Returns test-case names for outputting nicely with pytest.
+    """
+    suffix = "passing_contracts" if passing else "failing_contracts"
+    return [p.name for p in (BASE_CONTRACTS_PATH / suffix).glob("*.vy")]
+
+
+PASSING_CONTRACT_NAMES = contract_test_cases(True)
+FAILING_CONTRACT_NAMES = contract_test_cases(False)
+EXPECTED_FAIL_MESSAGES = {
+    "contract_undeclared_variable": "'hello' has not been declared",
+    "contract_unknown_pragma": "",
+}
+
+
+@pytest.mark.parametrize("contract_name", PASSING_CONTRACT_NAMES)
+def test_pass(contract_name, compiler):
+    path = BASE_CONTRACTS_PATH / "passing_contracts" / contract_name
     assert compiler.compile([path])
 
 
-@pytest.mark.parametrize("path", FAILING_CONTRACTS_FOLDER.glob("*.vy"))
-def test_failure(path, compiler):
-    with pytest.raises(Exception):
+@pytest.mark.parametrize(
+    "contract_name", [n for n in FAILING_CONTRACT_NAMES if n != "contract_unknown_pragma.vy"]
+)
+def test_failure_from_compile(contract_name, compiler):
+    path = BASE_CONTRACTS_PATH / "failing_contracts" / contract_name
+    with pytest.raises(VyperCompileError) as err:
         compiler.compile([path])
+
+    assert isinstance(err.value.base_err, VyperError)
+    assert EXPECTED_FAIL_MESSAGES[path.stem] in str(err.value)
+
+
+def test_failure_from_install(compiler):
+    path = BASE_CONTRACTS_PATH / "failing_contracts" / "contract_unknown_pragma.vy"
+    with pytest.raises(VyperInstallError) as err:
+        compiler.compile([path])
+
+    assert str(err.value) == "No available version to install."


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #26

### How I did it

Follow advice from @fubuloubu 

1. Raise compiler-centric error in the compile phase that actually preserves the std-err data OR uses the natural exception in the error output.
2. Other error improvements.

### How to verify it

Make sure you can see the compile related errors in bad vyper code, e.g.:
```

ERROR: (VyperCompileError) vyper.exceptions.StructureException: Unsupported syntax for module namespace: Expr
  contract "/var/folders/hg/17b1zhsn1n3d8b4rgh6ntt_w0000gn/T/vyper-ajp3wgog.vy", line 1:0
  ---> 1 asdfasdfasdf
  -------^
       2

[15687] Failed to execute script vyper_compile
```

^ Not exactly sure where the `[15687] Failed to execute script vyper_compile` comes from though

Also, make sure good vyper good still compiles!



### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
