### PR TITLE
fix: adhere to correct ethpm-types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 addopts = """
-    -n auto
     -p no:ape_test
     --cov-branch
     --cov-report term

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0b2",
+        "eth-ape>=0.1.0b4",
         "tqdm>=4.62.3,<5.0",
         "vvm>=0.1.0,<0.2.0",
     ],


### PR DESCRIPTION
### What I did

Requires release of https://github.com/ApeWorX/ape/pull/408

Correct all validation errors from ethpm-types! Fixes paths in the package manifest to use a base path of the project's `contracts/` directory.

### How I did it

set the base path in the compiler as well as read the bytes assuming such base path.
Because we don't have access to the `ProjectManager` here (to get the `contracts/` directory path), I just made a config property for the base path.

### How to verify it

Make sure using this plus PR 408 in ape core that you can compile contracts and that your source IDs are paths.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
