### PR TITLE
fix: allow source install of vyper

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -1,7 +1,6 @@
 import json
 import re
 import shutil
-from importlib import import_module
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -1,8 +1,8 @@
 import json
 import re
+import shutil
 from importlib import import_module
 from pathlib import Path
-import shutil
 from typing import Dict, List, Optional, Set, Union
 
 import vvm  # type: ignore
@@ -131,7 +131,7 @@ class VyperCompiler(CompilerAPI):
                     source,
                     base_path=base_path,
                     vyper_version=vyper_version,
-                    vyper_binary=shutil.which("vyper") or None
+                    vyper_binary=shutil.which("vyper") or None,
                 )["<stdin>"]
             except Exception as err:
                 raise VyperCompileError(err) from err

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -107,13 +107,7 @@ class VyperCompiler(CompilerAPI):
                 if pragma_spec and not pragma_spec.select(self.installed_versions):
                     vyper_version = pragma_spec.select(self.available_versions)
 
-                    try:
-                        # Check if 'vyper' installed as package
-                        vyper_package_version = import_module("vyper").__version__  # type: ignore
-                    except ModuleNotFoundError:
-                        vyper_package_version = None
-
-                    if vyper_version and vyper_version != vyper_package_version:
+                    if vyper_version and vyper_version != self.package_version:
                         _install_vyper(vyper_version)
                     else:
                         raise VyperInstallError("No available version to install.")


### PR DESCRIPTION
### What I did

Fix bug preventing local install of `vyper` package from working.

### How I did it

Two things had to be done:

1. Checks to make sure we **don't** attempt to download the package if we detect we are using the version we have in our site-packages. (detected using the pragma spec).
2. Specify the path to the binary. This is needed so we can still use the `vvm` method.

### How to verify it

Two cases needed for testing (that I have tried myself too):

Case 1:

1. Install `vyper` from source (either a local clone or via `git`)
2. Compile a contract using the _next_ bumped version. Right now, the latest tag on `vyper` is `0.3.1`, so set your pragma to `0.3.2`. It should work now!

Case 2 (regression test):

1. Make sure you **do not** have vyper installed locally.
2. Specify a pragma from a released tag, such as `0.3.1`.
3. Notice you can compile 

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
