### PR TITLE
chore: support python 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.7, 3.8, 3.9, 3.10]
 
         steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.7, 3.8, 3.9, 3.10]
+                python-version: [3.7, 3.8, 3.9, "3.10"]
 
         steps:
         - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     -   id: check-yaml
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
+    rev: v5.10.1
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: black
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.950
     hooks:
     -   id: mypy
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -142,7 +142,6 @@ class VyperCompiler(CompilerAPI):
             result["sourceId"] = contract_path
             result["deploymentBytecode"] = {"bytecode": result["bytecode"]}
             result["runtimeBytecode"] = {"bytecode": result["bytecode_runtime"]}
-
             contract_types.append(ContractType.parse_obj(result))
 
         return contract_types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ write_to = "ape_vyper/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ extras_require = {
     ],
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.910,<1.0",  # Static type analyzer
+        "mypy>=0.950,<1.0",  # Static type analyzer
         "flake8>=3.9.2,<4.0",  # Style linter
-        "isort>=5.9.3,<6.0",  # Import sorting linter
+        "isort>=5.10.1,<6.0",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.2.1,<0.3.0",
+        "eth-ape>=0.2.2,<0.3.0",
         "tqdm>=4.62.3,<5.0",
         "vvm>=0.1.0,<0.2.0",
     ],
-    python_requires=">=3.7.2,<3.10",
+    python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,
     py_modules=["ape_vyper"],
     license="Apache-2.0",
@@ -76,5 +76,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
### What I did

* Add python 3.10 support now that vyper-lang is able to support it

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
