### PR TITLE
feat: add source map to contract type output

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -135,6 +135,8 @@ class VyperCompiler(CompilerAPI):
                 result["sourceId"] = contract_path
                 result["deploymentBytecode"] = {"bytecode": result["bytecode"]}
                 result["runtimeBytecode"] = {"bytecode": result["bytecode_runtime"]}
+                result["sourcemap"] = result["source_map"]["pc_pos_map_compressed"]
+                result["pcmap"] = result["source_map"]["pc_pos_map"]
                 contract_types.append(ContractType.parse_obj(result))
 
         return contract_types


### PR DESCRIPTION
This corresponds with https://github.com/ApeWorX/ethpm-types/pull/47 to ensure we have `ContractType.sourcemap` and `ContractType.pcmap` available when compiling Vyper contracts