### PR TITLE
test: use auto-generated vvm install path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,12 @@ If you are opening a work-in-progress pull request to verify that it passes CI t
 [marking it as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
 
 Join the Ethereum Python [Discord](https://discord.gg/PcEJ54yX) if you have any questions.
+
+## Testing
+
+By default, the test suite will use a new, temporary path for the Vyper compiler installations.
+This ensures that the tests always run from a clean slate without any relying on existing installations.
+
+If you wish to use your existing `~/.vvm` installations instead, you must set the environment variable `APE_VYPER_USE_SYSTEM_VYPER=1`.
+
+This will ensure that vvm's default path will be used, but any compilers installed as part of the tests will not be removed after tests have completed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
@@ -24,7 +25,10 @@ def _tmp_vvm_path(monkeypatch):
         shutil.rmtree(vvm_install_path, ignore_errors=True)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(
+    scope="session",
+    autouse=os.environ.get("APE_VYPER_USE_SYSTEM_VYPER") is None,
+)
 def setup_session_vvm_path(request):
     """
     Creates a new, temporary installation path for vvm when the test suite is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,55 @@
+import shutil
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import mkdtemp
+
 import pytest  # type: ignore
+import vvm  # type: ignore
 
 from ape_vyper.compiler import VyperCompiler
+
+
+@contextmanager
+def _tmp_vvm_path(monkeypatch):
+    vvm_install_path = mkdtemp()
+
+    monkeypatch.setenv(
+        vvm.install.VVM_BINARY_PATH_VARIABLE,
+        vvm_install_path,
+    )
+
+    yield vvm_install_path
+
+    if Path(vvm_install_path).is_dir():
+        shutil.rmtree(vvm_install_path, ignore_errors=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_session_vvm_path(request):
+    """
+    Creates a new, temporary installation path for vvm when the test suite is
+    run.
+
+    This ensures the Vyper installations do not conflict with the user's
+    installed versions and that the installations from the tests are cleaned up
+    after the suite is finished.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+
+    patch = MonkeyPatch()
+    request.addfinalizer(patch.undo)
+
+    with _tmp_vvm_path(patch) as path:
+        yield path
+
+
+@pytest.fixture
+def temp_vvm_path(monkeypatch):
+    """
+    Creates a new, temporary installation path for vvm for a given test.
+    """
+    with _tmp_vvm_path(monkeypatch) as path:
+        yield path
 
 
 @pytest.fixture


### PR DESCRIPTION
### What I did

Separated the test suite's vvm installations from the user's, which also ensures the tests
start from a clean slate on each run

fixes: #49 

### How I did it

Added a session scoped, auto-used pytest fixture for setting the install path at startup and cleaning it up at teardown

### How to verify it

Clean out your `~/.vvm` directory, run the tests, and verify that no Vyper installations are there after the suite completes.

Also should note starting up the test suite may take a tiny bit longer just because it's now downloading the Vyper binaries when it needs them, rather than relying on the real installations that may be present.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
