### PR TITLE
fix: use python3 as pre-commit default language

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,4 @@ repos:
 
 
 default_language_version:
-    python: python3.8
+    python: python3


### PR DESCRIPTION
### What I did
Fix pre-commit specifying a specific python version

### How I did it
`python3.9` -> `python3` under `default_language_version`

### How to verify it
Should be able to run pre-commit without explicitly having Python 3.9.x

### Checklist
- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
