### PR TITLE
feat: add ContractType.dev_messages support

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -138,9 +138,10 @@ class VyperCompiler(CompilerAPI):
                 result["pcmap"] = result["source_map"]["pc_pos_map"]
 
                 dev_messages = {}
-                for line_num, line in enumerate(source.split("\n")):
-                    if match := re.search(r"#\s*dev\s*:\s*(.+)", line):
-                        dev_messages[line_num + 1] = match.group(1).strip()
+                dev_msg_pattern = re.compile(r"#\s*dev\s*:\s*(.+)")
+                for line_index, line in enumerate(source.split("\n")):
+                    if match := re.search(dev_msg_pattern, line):
+                        dev_messages[line_index + 1] = match.group(1).strip()
 
                 result["dev_messages"] = dev_messages
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -138,7 +138,7 @@ class VyperCompiler(CompilerAPI):
                 result["pcmap"] = result["source_map"]["pc_pos_map"]
 
                 dev_messages = {}
-                dev_msg_pattern = re.compile(r"#\s*dev\s*:\s*(.+)")
+                dev_msg_pattern = re.compile(r"#\s*(dev:.+)")
                 for line_index, line in enumerate(source.split("\n")):
                     if match := re.search(dev_msg_pattern, line):
                         dev_messages[line_index + 1] = match.group(1).strip()

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-ape>=0.5.0,<0.6.0",
+        "ethpm-types>=0.3.12,<0.4.0",
         "tqdm>=4.62.3,<5.0",
         "vvm>=0.1.0,<0.2.0",
     ],

--- a/tests/contracts/passing_contracts/contract_with_dev_messages.vy
+++ b/tests/contracts/passing_contracts/contract_with_dev_messages.vy
@@ -1,0 +1,26 @@
+# @version 0.3.4
+
+# Test dev messages in various code placements
+@external
+def foo() -> bool:
+    return True # dev: foo
+
+
+# dev: bar
+@external
+def bar() -> bool:
+    return True
+
+
+@external
+def baz() -> bool: # dev: baz
+    return True
+
+# Test that whitespacing is non-specific
+#          dev    :      odd spacing
+
+# Test non-ascii character matching
+# dev: 你好，猿
+
+# Test that empty dev comments are ignored
+# dev:

--- a/tests/contracts/passing_contracts/contract_with_dev_messages.vy
+++ b/tests/contracts/passing_contracts/contract_with_dev_messages.vy
@@ -16,9 +16,6 @@ def bar() -> bool:
 def baz() -> bool: # dev: baz
     return True
 
-# Test that whitespacing is non-specific
-#          dev    :      odd spacing
-
 # Test non-ascii character matching
 # dev: 你好，猿
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -32,7 +32,7 @@ EXPECTED_FAIL_MESSAGES = {
 
 def test_compile_project(project):
     contracts = project.load_contracts()
-    assert len(contracts) == 4
+    assert len(contracts) == 5
     assert contracts["contract"].source_id == "contract.vy"
     assert contracts["contract_no_pragma"].source_id == "contract_no_pragma.vy"
     assert contracts["older_version"].source_id == "older_version.vy"
@@ -71,11 +71,12 @@ def test_get_version_map(project, compiler):
     fail_msg = f"Unexpected versions founds: {''.join(unexpected_versions)}"
     assert not unexpected_versions, fail_msg
     assert len(actual[OLDER_VERSION_FROM_PRAGMA]) == 1
-    assert len(actual[VERSION_FROM_PRAGMA]) == 3
+    assert len(actual[VERSION_FROM_PRAGMA]) == 4
     assert actual[OLDER_VERSION_FROM_PRAGMA] == {project.contracts_folder / "older_version.vy"}
     assert actual[VERSION_FROM_PRAGMA] == {
         project.contracts_folder / "contract.vy",
         project.contracts_folder / "contract_no_pragma.vy",
+        project.contracts_folder / "contract_with_dev_messages.vy",
         project.contracts_folder / "use_iface.vy",
     }
 
@@ -93,10 +94,35 @@ def test_compiler_data_in_manifest(project):
     for compiler in (vyper_028, vyper_034):
         assert compiler.name == "vyper"
 
-    assert len(vyper_034.contractTypes) == 3
+    assert len(vyper_034.contractTypes) == 4
     assert len(vyper_028.contractTypes) == 1
     assert "contract" in vyper_034.contractTypes
     assert "older_version" in vyper_028.contractTypes
     for compiler in (vyper_034, vyper_028):
         assert compiler.settings["evmVersion"] == "constantinople"
         assert compiler.settings["optimize"] is True
+
+
+def test_compile_parse_dev_messages(compiler):
+    """
+    Test parsing of dev messages in a contract. These follow the form of "#dev: ...".
+
+    The compiler will output a map that maps dev messages to line numbers.
+    See contract_with_dev_messages.vy for more information.
+    """
+    path = BASE_CONTRACTS_PATH / "passing_contracts" / "contract_with_dev_messages.vy"
+
+    result = compiler.compile([path])
+
+    assert len(result) == 1
+
+    contract = result[0]
+
+    assert contract.dev_messages is not None
+    assert len(contract.dev_messages) == 5
+    assert contract.dev_messages[6] == "foo"
+    assert contract.dev_messages[9] == "bar"
+    assert contract.dev_messages[16] == "baz"
+    assert contract.dev_messages[20] == "odd spacing"
+    assert contract.dev_messages[23] == "你好，猿"
+    assert 26 not in contract.dev_messages

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -119,10 +119,9 @@ def test_compile_parse_dev_messages(compiler):
     contract = result[0]
 
     assert contract.dev_messages is not None
-    assert len(contract.dev_messages) == 5
-    assert contract.dev_messages[6] == "foo"
-    assert contract.dev_messages[9] == "bar"
-    assert contract.dev_messages[16] == "baz"
-    assert contract.dev_messages[20] == "odd spacing"
-    assert contract.dev_messages[23] == "你好，猿"
-    assert 26 not in contract.dev_messages
+    assert len(contract.dev_messages) == 4
+    assert contract.dev_messages[6] == "dev: foo"
+    assert contract.dev_messages[9] == "dev: bar"
+    assert contract.dev_messages[16] == "dev: baz"
+    assert contract.dev_messages[20] == "dev: 你好，猿"
+    assert 23 not in contract.dev_messages


### PR DESCRIPTION
### What I did

fixes: APE-308

Requires https://github.com/ApeWorX/ethpm-types/pull/51
Facilitates https://github.com/ApeWorX/ape/pull/1125

### How I did it

During the `compile()` step we parse the source line-by-line and save the line number + message if we encounter a dev message (`#dev: foobar`)

### How to verify it

Via `test_compile_parse_dev_messages()` and the new `contract_with_dev_messages.vy` test contract.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
