### PR TITLE
test: ensure can have directory with `.vy` in the name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+*.swp
 **/.build
 
 # Byte-compiled / optimized / DLL files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
     -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,20 +10,21 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.991
     hooks:
     -   id: mypy
+        additional_dependencies: [types-setuptools]
 
 
 default_language_version:

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -207,7 +207,7 @@ class VyperCompiler(CompilerAPI):
     ) -> Dict[Version, Dict]:
         contracts_path = base_path or self.config_manager.contracts_folder
 
-        # Currently needed because of a bug in Ape core 0.5.5.
+        # Currently needed because of a bug in Ape core 0.5.6.
         only_files = []
         for path in contract_filepaths:
             if path.is_dir():

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -1,11 +1,12 @@
 import re
 import shutil
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, cast
 
 import vvm  # type: ignore
 from ape.api import PluginConfig
 from ape.api.compiler import CompilerAPI
+from ape.logging import logger
 from ape.types import ContractType
 from ape.utils import cached_property, get_relative_path
 from semantic_version import NpmSpec, Version  # type: ignore
@@ -51,7 +52,7 @@ def get_pragma_spec(source: str) -> Optional[NpmSpec]:
 class VyperCompiler(CompilerAPI):
     @property
     def config(self) -> VyperConfig:
-        return self.config_manager.get_config("vyper")  # type: ignore
+        return cast(VyperConfig, self.config_manager.get_config("vyper"))
 
     @property
     def name(self) -> str:
@@ -205,7 +206,18 @@ class VyperCompiler(CompilerAPI):
         self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> Dict[Version, Dict]:
         contracts_path = base_path or self.config_manager.contracts_folder
-        files_by_vyper_version = self.get_version_map(contract_filepaths, base_path=contracts_path)
+
+        # Currently needed because of a bug in Ape core 0.5.5.
+        only_files = []
+        for path in contract_filepaths:
+            if path.is_dir():
+                logger.error(
+                    f"Unable to get compiler settings for directory '{path.name}'. Skipping."
+                )
+            else:
+                only_files.append(path)
+
+        files_by_vyper_version = self.get_version_map(only_files, base_path=contracts_path)
         if not files_by_vyper_version:
             return {}
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, Set, Union, cast
 import vvm  # type: ignore
 from ape.api import PluginConfig
 from ape.api.compiler import CompilerAPI
-from ape.logging import logger
 from ape.types import ContractType
 from ape.utils import cached_property, get_relative_path
 from semantic_version import NpmSpec, Version  # type: ignore
@@ -206,18 +205,7 @@ class VyperCompiler(CompilerAPI):
         self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> Dict[Version, Dict]:
         contracts_path = base_path or self.config_manager.contracts_folder
-
-        # Currently needed because of a bug in Ape core 0.5.6.
-        only_files = []
-        for path in contract_filepaths:
-            if path.is_dir():
-                logger.error(
-                    f"Unable to get compiler settings for directory '{path.name}'. Skipping."
-                )
-            else:
-                only_files.append(path)
-
-        files_by_vyper_version = self.get_version_map(only_files, base_path=contracts_path)
+        files_by_vyper_version = self.get_version_map(contract_filepaths, base_path=contracts_path)
         if not files_by_vyper_version:
             return {}
 

--- a/ape_vyper/exceptions.py
+++ b/ape_vyper/exceptions.py
@@ -15,7 +15,7 @@ class VyperCompileError(CompilerError):
     def __init__(self, err: Exception):
         self.base_err = err
         if hasattr(err, "stderr_data"):
-            message = err.stderr_data  # type: ignore
+            message = err.stderr_data
         else:
             message = str(err)
 

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.5,<0.6.0",
-        "ethpm-types>=0.3.12,<0.4.0",
+        "eth-ape>=0.5.7,<0.6.0",
+        "ethpm-types",  # Use same version as eth-ape
         "tqdm>=4.62.3,<5.0",
         "vvm>=0.1.0,<0.2.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
@@ -10,9 +10,10 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=22.6.0",  # auto-formatter and linter
-        "mypy==0.982",  # Static type analyzer
-        "flake8>=4.0.1",  # Style linter
+        "black>=22.10.0",  # auto-formatter and linter
+        "mypy>=0.991",  # Static type analyzer
+        "types-setuptools",  # Needed due to mypy typeshed
+        "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this
@@ -53,7 +54,7 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.0,<0.6.0",
+        "eth-ape>=0.5.5,<0.6.0",
         "ethpm-types>=0.3.12,<0.4.0",
         "tqdm>=4.62.3,<5.0",
         "vvm>=0.1.0,<0.2.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import ape
-import pytest  # type: ignore
+import pytest
 import vvm  # type: ignore
 
 from ape_vyper.compiler import VyperCompiler

--- a/tests/contracts/passing_contracts/DirectoryWithExtension.vy/README.md
+++ b/tests/contracts/passing_contracts/DirectoryWithExtension.vy/README.md
@@ -1,0 +1,3 @@
+# Directory with Misleading Extension Test
+
+The existence of this directory is to test things still work when a directory with `.vy` in its name is present.

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -1,4 +1,4 @@
-# @version 0.3.8
+# @version 0.3.7
 
 @external
 def foo1() -> bool:

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -1,4 +1,4 @@
-# @version 0.3.4
+# @version 0.3.7
 
 @external
 def foo1() -> bool:

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -1,4 +1,4 @@
-# @version 0.3.7
+# @version 0.3.8
 
 @external
 def foo1() -> bool:

--- a/tests/contracts/passing_contracts/contract_with_dev_messages.vy
+++ b/tests/contracts/passing_contracts/contract_with_dev_messages.vy
@@ -1,4 +1,4 @@
-# @version 0.3.4
+# @version 0.3.7
 
 # Test dev messages in various code placements
 @external

--- a/tests/contracts/passing_contracts/contract_with_dev_messages.vy
+++ b/tests/contracts/passing_contracts/contract_with_dev_messages.vy
@@ -1,4 +1,4 @@
-# @version 0.3.8
+# @version 0.3.7
 
 # Test dev messages in various code placements
 @external

--- a/tests/contracts/passing_contracts/contract_with_dev_messages.vy
+++ b/tests/contracts/passing_contracts/contract_with_dev_messages.vy
@@ -1,4 +1,4 @@
-# @version 0.3.7
+# @version 0.3.8
 
 # Test dev messages in various code placements
 @external

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -11,7 +11,7 @@ BASE_CONTRACTS_PATH = Path(__file__).parent / "contracts"
 
 # Currently, this is the only version specified from a pragma spec
 OLDER_VERSION_FROM_PRAGMA = Version("0.2.8")
-VERSION_FROM_PRAGMA = Version("0.3.8")
+VERSION_FROM_PRAGMA = Version("0.3.7")
 
 
 def contract_test_cases(passing: bool) -> List[str]:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -11,7 +11,7 @@ BASE_CONTRACTS_PATH = Path(__file__).parent / "contracts"
 
 # Currently, this is the only version specified from a pragma spec
 OLDER_VERSION_FROM_PRAGMA = Version("0.2.8")
-VERSION_FROM_PRAGMA = Version("0.3.7")
+VERSION_FROM_PRAGMA = Version("0.3.8")
 
 
 def contract_test_cases(passing: bool) -> List[str]:


### PR DESCRIPTION
### What I did

Following suit with https://github.com/ApeWorX/ape/pull/1147/files and https://github.com/ApeWorX/ape-solidity/pull/82 but no bug here, only ensuring it works via adding new tests as well updating from template

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
