### PR TITLE
feat: implement `get_imports()` API method

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -62,7 +62,7 @@ class VyperCompiler(CompilerAPI):
     def evm_version(self) -> Optional[str]:
         return self.config.evm_version
 
-    def get_imports(  # type: ignore[empty-body]
+    def get_imports(
         self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> Dict[str, List[str]]:
         base_path = (base_path or self.project_manager.contracts_folder).absolute()

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -1,3 +1,4 @@
+import os
 import re
 import shutil
 from pathlib import Path
@@ -10,7 +11,7 @@ from ape.types import ContractType
 from ape.utils import cached_property, get_relative_path
 from semantic_version import NpmSpec, Version  # type: ignore
 
-from .exceptions import VyperCompileError, VyperInstallError
+from .exceptions import VyperCompileError, VyperCompilerPluginError, VyperInstallError
 
 
 class VyperConfig(PluginConfig):
@@ -60,6 +61,29 @@ class VyperCompiler(CompilerAPI):
     @property
     def evm_version(self) -> Optional[str]:
         return self.config.evm_version
+
+    def get_imports(  # type: ignore[empty-body]
+        self, contract_filepaths: List[Path], base_path: Optional[Path] = None
+    ) -> Dict[str, List[str]]:
+        base_path = (base_path or self.project_manager.contracts_folder).absolute()
+        import_map = {}
+        for path in contract_filepaths:
+            content = path.read_text().splitlines()
+            source_id = str(get_relative_path(path.absolute(), base_path.absolute()))
+            for line in content:
+                if line.startswith("import "):
+                    import_line_parts = line.replace("import ", "").split(" ")
+                    import_source_id = f"{Path(import_line_parts[0].replace('.', os.path.sep))}.vy"
+                    import_path = base_path / import_source_id
+                    if not import_path.is_file():
+                        raise VyperCompilerPluginError(f"Missing import source '{import_path}'.")
+
+                    if source_id not in import_map:
+                        import_map[source_id] = [import_source_id]
+                    elif import_source_id not in import_map[source_id]:
+                        import_map[source_id].append(source_id)
+
+        return import_map
 
     def get_versions(self, all_paths: List[Path]) -> Set[str]:
         versions = set()

--- a/ape_vyper/exceptions.py
+++ b/ape_vyper/exceptions.py
@@ -1,13 +1,19 @@
 from ape.exceptions import CompilerError
 
 
-class VyperInstallError(CompilerError):
+class VyperCompilerPluginError(CompilerError):
+    """
+    An error raised in the Vyper compiler.
+    """
+
+
+class VyperInstallError(VyperCompilerPluginError):
     """
     An error raised failing to install Vyper.
     """
 
 
-class VyperCompileError(CompilerError):
+class VyperCompileError(VyperCompilerPluginError):
     """
     A compiler-specific error in Vyper.
     """

--- a/tests/contracts/passing_contracts/use_iface.vy
+++ b/tests/contracts/passing_contracts/use_iface.vy
@@ -1,4 +1,5 @@
 # @version ^0.3.3
+
 import interfaces.IFace as IFace
 
 

--- a/tests/contracts/passing_contracts/use_iface2.vy
+++ b/tests/contracts/passing_contracts/use_iface2.vy
@@ -1,0 +1,10 @@
+# @version ^0.3.3
+
+from interfaces import IFace as IFace
+
+
+@external
+@view
+def read_contract(some_address: address) -> uint256:
+    myContract: IFace = IFace(some_address)
+    return myContract.read_stuff()

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -131,3 +131,11 @@ def test_compile_parse_dev_messages(compiler):
     assert contract.dev_messages[16] == "dev: baz"
     assert contract.dev_messages[20] == "dev: 你好，猿"
     assert 23 not in contract.dev_messages
+
+
+def test_get_imports(compiler, project):
+    vyper_files = [
+        x for x in project.contracts_folder.iterdir() if x.is_file() and x.suffix == ".vy"
+    ]
+    actual = compiler.get_imports(vyper_files)
+    assert actual["use_iface.vy"] == ["interfaces/IFace.vy"]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -32,7 +32,9 @@ EXPECTED_FAIL_MESSAGES = {
 
 def test_compile_project(project):
     contracts = project.load_contracts()
-    assert len(contracts) == 5
+    assert len(contracts) == len(
+        [p.name for p in (BASE_CONTRACTS_PATH / "passing_contracts").glob("*.vy") if p.is_file()]
+    )
     assert contracts["contract"].source_id == "contract.vy"
     assert contracts["contract_no_pragma"].source_id == "contract_no_pragma.vy"
     assert contracts["older_version"].source_id == "older_version.vy"
@@ -77,13 +79,14 @@ def test_get_version_map(project, compiler):
         pytest.fail(fail_message)
 
     assert len(actual[OLDER_VERSION_FROM_PRAGMA]) == 1
-    assert len(actual[VERSION_FROM_PRAGMA]) == 4
+    assert len(actual[VERSION_FROM_PRAGMA]) == 5
     assert actual[OLDER_VERSION_FROM_PRAGMA] == {project.contracts_folder / "older_version.vy"}
     assert actual[VERSION_FROM_PRAGMA] == {
         project.contracts_folder / "contract.vy",
         project.contracts_folder / "contract_no_pragma.vy",
         project.contracts_folder / "contract_with_dev_messages.vy",
         project.contracts_folder / "use_iface.vy",
+        project.contracts_folder / "use_iface2.vy",
     }
 
 
@@ -100,7 +103,7 @@ def test_compiler_data_in_manifest(project):
     for compiler in (vyper_028, vyper_034):
         assert compiler.name == "vyper"
 
-    assert len(vyper_034.contractTypes) == 4
+    assert len(vyper_034.contractTypes) == 5
     assert len(vyper_028.contractTypes) == 1
     assert "contract" in vyper_034.contractTypes
     assert "older_version" in vyper_028.contractTypes

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -139,3 +139,4 @@ def test_get_imports(compiler, project):
     ]
     actual = compiler.get_imports(vyper_files)
     assert actual["use_iface.vy"] == ["interfaces/IFace.vy"]
+    assert actual["use_iface2.vy"] == ["interfaces/IFace.vy"]


### PR DESCRIPTION
### What I did

fixes: #43 
Fixes: APE-406
This is needed for Etherscan verification and I think also helps Ape core compile Vyper projects (IICR why we did it in `ape-solidity`).

This is step 1 to getting Verification working for Vyper contracts.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
