### PR TITLE
refactor: utilize AST map to derive PC Map [APE-670]

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -259,7 +259,8 @@ class VyperCompiler(CompilerAPI):
                         pc += 1
                         if src.start is not None and src.length is not None:
                             stmt = ast.get_statement(src)
-                            pc_map[str(pc)] = list(stmt.pcmap)
+                            if stmt:
+                                pc_map[str(pc)] = list(stmt.pcmap)
 
                     # Find dev messages.
                     dev_messages = {}

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -258,11 +258,7 @@ class VyperCompiler(CompilerAPI):
 
                         pc += 1
                         if src.start is not None and src.length is not None:
-                            stmt = [
-                                s
-                                for s in ast.statements
-                                if src.start == s.src.start and src.length == s.src.length
-                            ][0]
+                            stmt = ast.get_statement(src)
                             pc_map[str(pc)] = list(stmt.pcmap)
 
                     # Find dev messages.

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -258,9 +258,9 @@ class VyperCompiler(CompilerAPI):
 
                         pc += 1
                         if src.start is not None and src.length is not None:
-                            stmt = ast.get_statement(src)
+                            stmt = ast.get_node(src)
                             if stmt:
-                                pc_map[str(pc)] = list(stmt.pcmap)
+                                pc_map[str(pc)] = list(stmt.line_numbers)
 
                     # Find dev messages.
                     dev_messages = {}

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -260,7 +260,7 @@ class VyperCompiler(CompilerAPI):
                         if src.start is not None and src.length is not None:
                             stmt = ast.get_node(src)
                             if stmt:
-                                pc_map[str(pc)] = list(stmt.line_numbers)
+                                pc_map[pc] = list(stmt.line_numbers)
 
                     # Find dev messages.
                     dev_messages = {}

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.3,<0.7",
+        "eth-ape>=0.6.4,<0.7",
         "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.1.0,<0.2",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "asttokens>=2.1.0,<3",
         "eth-ape>=0.6.3,<0.7",
         "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -3,5 +3,5 @@
 from vyper.interfaces import ERC20
 
 @external
-def foo1() -> bool:
-    return True
+def setNumber(num: uint256):
+    assert num != 5  # dev: 7 8 9

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -158,15 +158,16 @@ def test_get_imports(compiler, project):
     assert set(actual["use_iface2.vy"]) == {local_import}
 
 
-def test_pc_map(compiler, project, dev_revert_source):
+def test_pc_map(compiler, project):
     """
     Ensure we de-compress the source map correctly by comparing to the results
     from `compile_src()` which includes the uncompressed source map data.
     """
 
-    result = compiler.compile([dev_revert_source], base_path=PASSING_BASE)[0]
+    path = PASSING_BASE / "contract.vy"
+    result = compiler.compile([path], base_path=PASSING_BASE)[0]
     actual = result.pcmap.__root__
-    code = dev_revert_source.read_text()
+    code = path.read_text()
     src_map = compile_source(code)["<stdin>"]["source_map"]
     expected = src_map["pc_pos_map"]
     assert actual == expected


### PR DESCRIPTION
### What I did

* Realized can make the PC Map from the output AST JSON.
* This allows removing `asttokens` as a dependency which increases compatibility with out languages written in Python (old-school Cairo)
* Also begins to form an idea on how to use this AST JSON... I am soliciting ideas on how we can include this in `ethpm-types` for generating an overall coverage profile. There are different node types between Vyper and Solidity, so have to keep it relatively generic. 
* Adds `ast` to `ContractType`

### How I did it

Mostly in this PR https://github.com/ApeWorX/ethpm-types/pull/61

### How to verify it

* Things still work
* Now have AST data structure in ContractTypes that we can use for accurate Coverage profiles

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
