### PR TITLE
feat: `trace_source` implementation [APE-754]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,9 @@ jobs:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
                 python-version: [3.8, 3.9, "3.10"]
 
+        env:
+          GETH_VERSION: 1.11.5
+
         steps:
         - uses: actions/checkout@v3
 
@@ -75,6 +78,29 @@ jobs:
           uses: actions/setup-python@v4
           with:
               python-version: ${{ matrix.python-version }}
+
+        - name: Setup Go
+          uses: actions/setup-go@v4
+          with:
+            go-version: '^1.20.1'
+
+        - name: Cache Geth
+          id: cache-geth
+          uses: actions/cache@v3
+          with:
+            path: $HOME/.local/bin
+            key: ${{ runner.os }}-geth-${{ env.GETH_VERSION }}
+
+        - name: Install Geth
+          if: steps.cache-geth.outputs.cache-hit != 'true'
+          run: |
+            mkdir -p $HOME/.local/bin
+            wget -O geth.tar.gz "https://github.com/ethereum/go-ethereum/archive/v$GETH_VERSION.tar.gz"
+            tar -zxvf geth.tar.gz
+            cd go-ethereum-$GETH_VERSION
+            make geth
+            cp ./build/bin/geth /usr/local/bin
+            geth version
 
         - name: Install Dependencies
           run: |

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -250,7 +250,7 @@ class VyperCompiler(CompilerAPI):
 
             def classify_ast(node: ASTNode):
                 if node.ast_type in _FUNCTION_AST_TYPES:
-                    node.classification = ASTClassification.FUNCTION_DEF
+                    node.classification = ASTClassification.FUNCTION
 
                 for child in node.children:
                     classify_ast(child)

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -578,7 +578,7 @@ class VyperCompiler(CompilerAPI):
             if frame.pc not in pcmap:
                 continue
 
-            location = cast(Tuple[int, int, int, int], tuple(pcmap[frame.pc]["location"] or []))
+            location = cast(Tuple[int, int, int, int], tuple(pcmap[frame.pc].get("location") or []))
             if not location:
                 # Is builtin PC marker.
                 continue

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -251,10 +251,6 @@ class VyperCompiler(CompilerAPI):
             def classify_ast(node: ASTNode):
                 if node.ast_type in _FUNCTION_AST_TYPES:
                     node.classification = ASTClassification.FUNCTION_DEF
-                    if node.ast_type == "FunctionDef":
-                        for child in node.children:
-                            if child.ast_type not in _FUNCTION_AST_TYPES:
-                                child.classification = ASTClassification.CONTENT
 
                 for child in node.children:
                     classify_ast(child)

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -579,6 +579,10 @@ class VyperCompiler(CompilerAPI):
                 continue
 
             location = cast(Tuple[int, int, int, int], tuple(pcmap[frame.pc]["location"] or []))
+            if not location:
+                # Is builtin PC marker.
+                continue
+
             function = contract_src.lookup_function(location, method_id=HexBytes(calldata[:4]))
             if not function:
                 continue

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -564,8 +564,8 @@ class VyperCompiler(CompilerAPI):
                 # Check if next op is SSTORE to properly use AST from push op.
                 next_frame = next(trace, None)
                 if next_frame and next_frame.op == "SSTORE":
-                    push_location = tuple(contract_src.pcmap[frame.pc])  # type: ignore
-                    pcmap = PCMap.parse_obj({next_frame.pc: push_location})
+                    push_location = tuple(contract_src.pcmap[frame.pc]["location"])  # type: ignore
+                    pcmap = PCMap.parse_obj({next_frame.pc: {"location": push_location}})
                 else:
                     pcmap = contract_src.pcmap
 
@@ -578,7 +578,7 @@ class VyperCompiler(CompilerAPI):
             if frame.pc not in pcmap:
                 continue
 
-            location = cast(Tuple[int, int, int, int], tuple(pcmap[frame.pc] or []))
+            location = cast(Tuple[int, int, int, int], tuple(pcmap[frame.pc]["location"] or []))
             function = contract_src.lookup_function(location, method_id=HexBytes(calldata[:4]))
             if not function:
                 continue

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -249,11 +249,11 @@ class VyperCompiler(CompilerAPI):
             except VyperError as err:
                 raise VyperCompileError(err) from err
 
-            def classify_ast(node: ASTNode):
-                if node.ast_type in _FUNCTION_AST_TYPES:
-                    node.classification = ASTClassification.FUNCTION
+            def classify_ast(_node: ASTNode):
+                if _node.ast_type in _FUNCTION_AST_TYPES:
+                    _node.classification = ASTClassification.FUNCTION
 
-                for child in node.children:
+                for child in _node.children:
                     classify_ast(child)
 
             for source_id, output_items in result["contracts"].items():
@@ -610,7 +610,7 @@ class VyperCompiler(CompilerAPI):
                 # Empty source (is builtin)
                 closure = Closure(name=name)
                 depth = traceback.last.depth - 1 if traceback.last else 0
-                statement = Statement(type=error_type.name)
+                statement = Statement(type=f"dev: {error_type.value}")
                 flow = ControlFlow(
                     statements=[statement],
                     closure=closure,

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -13,8 +13,8 @@ from ape.utils import cached_property, get_relative_path
 from eth_utils import is_0x_prefixed
 from ethpm_types import ASTNode, HexBytes, PackageManifest, PCMap
 from ethpm_types.ast import ASTClassification
-from ethpm_types.contract_type import ContractSource, SourceMap
-from ethpm_types.source import Function
+from ethpm_types.contract_type import SourceMap
+from ethpm_types.source import ContractSource, Function
 from evm_trace.enums import CALL_OPCODES
 from semantic_version import NpmSpec, Version  # type: ignore
 from vvm.exceptions import VyperError  # type: ignore
@@ -629,7 +629,12 @@ class VyperCompiler(CompilerAPI):
                     if traceback.last and traceback.last.depth == frame.depth
                     else frame.depth
                 )
-                traceback.add_jump(location, function, contract_src.source_path, depth)
+                traceback.add_jump(
+                    location,
+                    function,
+                    depth,
+                    source_path=contract_src.source_path,
+                )
             else:
                 traceback.extend_last(location)
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -28,7 +28,6 @@ from ape_vyper.exceptions import (
 
 DEV_MSG_PATTERN = re.compile(r"#\s*(dev:.+)")
 _RETURN_OPCODES = ("RETURN", "REVERT", "STOP")
-_CALL_OPCODES = tuple([x.value for x in CALL_OPCODES])
 _FUNCTION_DEF = "FunctionDef"
 _FUNCTION_AST_TYPES = (_FUNCTION_DEF, "Name", "arguments")
 
@@ -519,7 +518,7 @@ class VyperCompiler(CompilerAPI):
         function = None
 
         for frame in trace:
-            if frame.op in _CALL_OPCODES:
+            if frame.op in CALL_OPCODES:
                 called_contract, sub_calldata = self._create_contract_from_call(frame)
                 if called_contract:
                     ext = Path(called_contract.source_id).suffix

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.8,<0.7",
+        "eth-ape>=0.6.9,<0.7",
         "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.1.0,<0.2",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-ape>=0.6.8,<0.7",
-        "ethpm-types>=0.4.4",
+        "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.1.0,<0.2",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,19 @@ def project(config):
         yield project
         if project.local_project._cache_folder.is_dir():
             shutil.rmtree(project.local_project._cache_folder)
+
+
+@pytest.fixture
+def geth_provider():
+    if not ape.networks.active_provider or ape.networks.provider.name != "geth":
+        with ape.networks.ethereum.local.use_provider(
+            "geth", provider_settings={"uri": "http://127.0.0.1:5550"}
+        ) as provider:
+            yield provider
+    else:
+        yield ape.networks.provider
+
+
+@pytest.fixture
+def account():
+    return ape.accounts.test_accounts[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,3 +105,13 @@ def geth_provider():
 @pytest.fixture
 def account():
     return ape.accounts.test_accounts[0]
+
+
+@pytest.fixture
+def registry(geth_provider, account, project):
+    return account.deploy(project.registry)
+
+
+@pytest.fixture
+def contract(registry, account, project):
+    return account.deploy(project.traceback_contract, registry)

--- a/tests/contracts/passing_contracts/interfaces/IRegistry.vy
+++ b/tests/contracts/passing_contracts/interfaces/IRegistry.vy
@@ -1,0 +1,9 @@
+# @version 0.3.7
+
+@external
+def register(addr: address):
+    pass
+
+@external
+def register_f(addr: address):
+    pass

--- a/tests/contracts/passing_contracts/registry.vy
+++ b/tests/contracts/passing_contracts/registry.vy
@@ -1,0 +1,13 @@
+# @version 0.3.7
+
+addr: public(address)
+
+@external
+def register(addr: address):
+    self.addr = addr
+
+
+@external
+def register_f(addr: address):
+    assert self.addr != addr, "doubling."
+    self.addr = addr

--- a/tests/contracts/passing_contracts/traceback_contract.vy
+++ b/tests/contracts/passing_contracts/traceback_contract.vy
@@ -1,0 +1,62 @@
+# @version 0.3.7
+
+import interfaces.IRegistry as IRegistry
+
+_balance: public(uint256)
+registry: public(IRegistry)
+
+
+@external
+def __init__(registry: IRegistry):
+    self.registry = registry
+
+
+@external
+def addBalance(
+    num: uint256
+) -> uint256:
+    assert num != self._balance
+    self.registry.register(msg.sender)
+    self._balance = self._balance + self.addInterest(num)
+
+    # Run some loops.
+    for i in [1, 2, 3, 4, 5]:
+        if i == num:
+            break
+
+    # Comments in the middle (is a test)
+
+    for i in [1, 2, 3, 4, 5]:
+        if i != num:
+            continue
+
+    return self._balance
+
+
+@external
+def addBalance_f(
+    num: uint256
+) -> uint256:
+    assert num != self._balance
+    self.registry.register(msg.sender)
+    self._balance = self._balance + self.addInterest(num)
+
+    # Run some loops.
+    for i in [1, 2, 3, 4, 5]:
+        if i == num:
+            break
+
+    # Fail in the middle (is test)
+    # Fails because was already set above.
+    self.registry.register_f(msg.sender)
+
+    for i in [1, 2, 3, 4, 5]:
+        if i != num:
+            continue
+
+    return self._balance
+
+
+@internal
+def addInterest(num: uint256) -> uint256:
+    return 123 + num

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -270,11 +270,11 @@ def test_enrich_error(compiler, geth_provider, contract, account):
 
 def test_trace_source(account, geth_provider, project, contract):
     receipt = contract.addBalance(123, sender=account)
-    actual = receipt.traceback
+    actual = receipt.source_traceback
     base_folder = project.contracts_folder
     expected = rf"""
 Traceback (most recent call last)
-  File {base_folder}/traceback_contract.vy, in addBalance(uint256 num) -> uint256
+  File {base_folder}/traceback_contract.vy, in addBalance
        27     # Comments in the middle (is a test)
        28
        29     for i in [1, 2, 3, 4, 5]:
@@ -297,11 +297,11 @@ def test_trace_err_source(account, geth_provider, project):
         pass
 
     receipt = geth_provider.get_receipt(txn.txn_hash.hex())
-    actual = receipt.traceback
+    actual = receipt.source_traceback
     base_folder = project.contracts_folder
     expected = rf"""
 Traceback (most recent call last)
-  File {base_folder}/traceback_contract.vy, in addBalance_f(uint256 num) -> uint256
+  File {base_folder}/traceback_contract.vy, in addBalance_f
        44     # Run some loops.
        45     for i in [1, 2, 3, 4, 5]:
        46         if i == num:
@@ -315,7 +315,7 @@ Traceback (most recent call last)
        54         if i != num:
        55             continue
 
-  File {base_folder}/registry.vy, in register_f(address addr)
+  File {base_folder}/registry.vy, in register_f
   -->  12     assert self.addr != addr, "doubling."
        13     self.addr = addr
     """.strip()


### PR DESCRIPTION
### What I did

Implements necessary API methods for performing traceback line showings as well as coverage.

### How I did it

Implementation borrowed from Brownie somewhat, but basically track the trace while mapping PC to known locations, including both from the source code as well as from the error map.

### How to verify it

Use this PR from ape core: https://github.com/ApeWorX/ape/pull/1337 and cause uncaught contract logic errors to happen of any kind.
Observe them in the traceback.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
