### PR TITLE
fix: issue with immutable member access in PCMap calculation [APE-909]

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -19,7 +19,9 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: pip install commitizen
+          run: |
+            python -m pip install --upgrade pip
+            pip install commitizen
 
         - name: Check commit history
           run: cz check --rev-range $(git rev-list --all --reverse | head -1)..HEAD

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -20,7 +20,9 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: pip install commitizen
+          run: |
+            python -m pip install --upgrade pip
+            pip install commitizen
 
         - name: Check PR Title
           env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,9 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: pip install .[lint]
+          run: |
+            python -m pip install --upgrade pip
+            pip install .[lint]
 
         - name: Run Black
           run: black --check .
@@ -51,7 +53,9 @@ jobs:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: pip install .[lint,test]  # Might need test deps
+          run: |
+            python -m pip install --upgrade pip
+            pip install .[lint,test]  # Might need test deps
 
         - name: Run MyPy
           run: mypy .
@@ -73,7 +77,9 @@ jobs:
               python-version: ${{ matrix.python-version }}
 
         - name: Install Dependencies
-          run: pip install .[test]
+          run: |
+            python -m pip install --upgrade pip
+            pip install .[test]
 
         - name: Run Tests
           run: pytest -m "not fuzzing" -n 0 -s --cov
@@ -94,7 +100,9 @@ jobs:
 #              python-version: 3.8
 #
 #        - name: Install Dependencies
-#          run: pip install .[test]
+#          run: |
+#             python -m pip install --upgrade pip
+#             pip install .[test]
 #
 #        - name: Run Tests
 #          run: pytest -m "fuzzing" --no-cov -s

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -243,6 +243,10 @@ class VyperCompiler(CompilerAPI):
                 raise VyperCompileError(err) from err
 
             for source_id, output_items in result["contracts"].items():
+                content = {
+                    i + 1: ln
+                    for i, ln in enumerate((base_path / source_id).read_text().splitlines())
+                }
                 for name, output in output_items.items():
                     # De-compress source map to get PC POS map.
                     ast = ASTNode.parse_obj(result["sources"][source_id]["ast"])
@@ -252,10 +256,6 @@ class VyperCompiler(CompilerAPI):
                     src_map = list(compressed_src_map.parse())[1:]
                     pc = 0
                     pc_map_list: List[Tuple[int, Dict[str, Optional[Any]]]] = []
-                    content = {
-                        i + 1: ln
-                        for i, ln in enumerate((base_path / source_id).read_text().splitlines())
-                    }
                     last_value = None
                     revert_pc = -1
                     if _is_nonpayable_check(opcodes):
@@ -274,6 +274,7 @@ class VyperCompiler(CompilerAPI):
                         processed_opcodes.append(op)
                         start_pc = pc
                         pc += 1
+
                         if opcodes and is_0x_prefixed(opcodes[0]):
                             last_value = int(opcodes.pop(0), 16)
                             pc += int(op[4:])

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -255,6 +255,8 @@ class VyperCompiler(CompilerAPI):
                     function_offsets = []
                     for node in ast.children:
                         lineno = node.lineno
+
+                        # NOTE: Constructor is handled elsewhere.
                         if node.ast_type == "FunctionDef" and "__init__" not in content.get(
                             lineno, ""
                         ):

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -275,12 +275,11 @@ class VyperCompiler(CompilerAPI):
                         start_pc = pc
                         pc += 1
 
-                        if len(opcodes) > 5 and opcodes[5] == "CODECOPY":
-                            # Detect immutable state member load.
-                            # If this is the case, ignore increasing pc by push size.
-                            pass
+                        # Detect immutable state member load.
+                        # If this is the case, ignore increasing pc by push size.
+                        is_code_copy = len(opcodes) > 5 and opcodes[5] == "CODECOPY"
 
-                        elif opcodes and is_0x_prefixed(opcodes[0]):
+                        if not is_code_copy and opcodes and is_0x_prefixed(opcodes[0]):
                             last_value = int(opcodes.pop(0), 16)
                             # Add the push number, e.g. PUSH1 adds `1`.
                             pc += int(op[4:])

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -289,9 +289,10 @@ class VyperCompiler(CompilerAPI):
                                     "location": None,
                                     "dev": f"dev: {RuntimeErrorType.NONPAYABLE_CHECK.value}",
                                 }
-                                pc_map_list.append(
-                                    (pc if op == "REVERT" else start_pc, pc_map_item)
-                                )
+                                pc_key = pc if op == "REVERT" else start_pc
+                                if pc_key not in [x[0] for x in pc_map_list]:
+                                    # Shouldn't have an actual source pointer.
+                                    pc_map_list.append((pc_key, pc_map_item))
 
                             continue
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -275,8 +275,14 @@ class VyperCompiler(CompilerAPI):
                         start_pc = pc
                         pc += 1
 
-                        if opcodes and is_0x_prefixed(opcodes[0]):
+                        if len(opcodes) > 5 and opcodes[5] == "CODECOPY":
+                            # Detect immutable state member load.
+                            # If this is the case, ignore increasing pc by push size.
+                            pass
+
+                        elif opcodes and is_0x_prefixed(opcodes[0]):
                             last_value = int(opcodes.pop(0), 16)
+                            # Add the push number, e.g. PUSH1 adds `1`.
                             pc += int(op[4:])
 
                         # Check for special Payable case.

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-ape>=0.6.8,<0.7",
-        "ethpm-types>=0.4.3",  # Use same version as eth-ape
+        "ethpm-types>=0.4.4",
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.1.0,<0.2",
     ],

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -36,8 +36,13 @@ def setNumber(num: uint256):
     # NOTE: This `and` statement `assert` purposely tests something
     #  we had an issue where this causes the PCMap calculation to get thrown off.
     assert num != 5 and num != 5556  # dev: 7 8 9
+
     # Show that PCMap can handle log statements.
     log Swap(msg.sender, msg.sender, 1, 2, 3, 4)
+
+    # WARN: This part is really important.
+    # We had a bug where doing this caused PC calculation to be off.
+    ERC20Ext(token).decimals()
 
 
 @external

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -6,7 +6,8 @@ interface ERC20Ext:
     def decimals() -> uint8: view
 
 dynArray: public(DynArray[uint256, 1024])
-token: public(immutable(address))
+token: public(address)
+start_token: public(immutable(address))
 
 # NOTE: Keep constant as test for proving it doesn't fudge up PCMap.
 MASK: constant(uint256) = 2**96 - 1
@@ -28,7 +29,8 @@ def __init__(_token: address):
     @notice Constructor
     @param _token Include docs to prove it doesn't fudge with PCMap.
     """
-    token = _token
+    self.token = _token
+    start_token = _token
 
 
 @external
@@ -40,9 +42,13 @@ def setNumber(num: uint256):
     # Show that PCMap can handle log statements.
     log Swap(msg.sender, msg.sender, 1, 2, 3, 4)
 
+    # Test that we can access state variables and PCMap still works.
+    ERC20Ext(self.token).decimals()
+
     # WARN: This part is really important.
-    # We had a bug where doing this caused PC calculation to be off.
-    ERC20Ext(token).decimals()
+    # Specifically, the call to the immutable member start_token tests something.
+    # This is because immutable variables are code offsets and not storage slots.
+    ERC20Ext(self.start_token).decimals()
 
 
 @external

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -33,7 +33,9 @@ def __init__(_token: address):
 
 @external
 def setNumber(num: uint256):
-    assert num != 5  # dev: 7 8 9
+    # NOTE: This `and` statement `assert` purposely tests something
+    #  we had an issue where this causes the PCMap calculation to get thrown off.
+    assert num != 5 and num != 5556  # dev: 7 8 9
 
 
 @external

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -2,9 +2,34 @@
 
 from vyper.interfaces import ERC20
 
-dynArray: public(DynArray[uint256, 1024])
+interface ERC20Ext:
+    def decimals() -> uint8: view
 
+dynArray: public(DynArray[uint256, 1024])
+token: public(immutable(address))
+
+# NOTE: Keep constant as test for proving it doesn't fudge up PCMap.
 MASK: constant(uint256) = 2**96 - 1
+
+
+# NOTE: Keep event as test for proving it doesn't fudge up PCMap.
+event Swap:
+    account: indexed(address)
+    receiver: indexed(address)
+    asset_in: uint256
+    asset_out: uint256
+    amount_in: uint256
+    amount_out: uint256
+
+
+@external
+def __init__(_token: address):
+    """
+    @notice Constructor
+    @param _token Include docs to prove it doesn't fudge with PCMap.
+    """
+    token = _token
+
 
 @external
 def setNumber(num: uint256):

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -36,6 +36,8 @@ def setNumber(num: uint256):
     # NOTE: This `and` statement `assert` purposely tests something
     #  we had an issue where this causes the PCMap calculation to get thrown off.
     assert num != 5 and num != 5556  # dev: 7 8 9
+    # Show that PCMap can handle log statements.
+    log Swap(msg.sender, msg.sender, 1, 2, 3, 4)
 
 
 @external

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -48,7 +48,7 @@ def setNumber(num: uint256):
     # WARN: This part is really important.
     # Specifically, the call to the immutable member start_token tests something.
     # This is because immutable variables are code offsets and not storage slots.
-    ERC20Ext(self.start_token).decimals()
+    ERC20Ext(start_token).decimals()
 
 
 @external

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -4,6 +4,8 @@ from vyper.interfaces import ERC20
 
 dynArray: public(DynArray[uint256, 1024])
 
+MASK: constant(uint256) = 2**96 - 1
+
 @external
 def setNumber(num: uint256):
     assert num != 5  # dev: 7 8 9

--- a/tests/contracts/passing_contracts/contract.vy
+++ b/tests/contracts/passing_contracts/contract.vy
@@ -74,4 +74,3 @@ def mod_zero(i: int128) -> int128:
 @external
 def gimme(idx: uint256) -> uint256:
     return self.dynArray[idx]
-

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -209,18 +209,23 @@ def test_pc_map(compiler, project):
         if actual[expected_pc]["location"] != expected_loc:
             wrong_locs.append((expected_pc, expected_loc, matching_locs))
 
+    limit = 10  # Only show first ten failures of each category.
+
     def make_failure(title, ls):
         fail_format = "PC={pc}, Expected={ex} (ones in actual with thus={match})"
-        suffix = ", ".join([fail_format.format(pc=m, ex=e, match=mat) for m, e, mat in ls])
+        suffix = ", ".join([fail_format.format(pc=m, ex=e, match=mat) for m, e, mat in ls[:limit]])
         return f"{title}: {suffix}"
 
     failures = []
     if len(missing_pcs) != 0:
-        failures.append(make_failure("Missing PCs", missing_pcs))
+        failures.append((missing_pcs[0][0], make_failure("Missing PCs", missing_pcs)))
     if len(empty_locs) != 0:
-        failures.append(make_failure("Empty locations", empty_locs))
+        failures.append((empty_locs[0][0], make_failure("Empty locations", empty_locs)))
     if len(wrong_locs) != 0:
-        failures.append(make_failure("Wrong locations", wrong_locs))
+        failures.append((wrong_locs[0][0], make_failure("Wrong locations", wrong_locs)))
+
+    # Show first failures to occur first.
+    failures.sort(key=lambda x: x[0])
 
     assert len(failures) == 0, "\n".join(failures)
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -212,6 +212,7 @@ def test_pc_map(compiler, project):
     expected["351"] = item(RuntimeErrorType.INDEX_OUT_OF_RANGE, [range_no, 11, range_no, 24])
     expected["392"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
     expected["405"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
+    expected["437"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
     assert actual == expected
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -191,19 +191,26 @@ def test_pc_map(compiler, project):
     wrong_locs = []
     for expected_pc, item_dict in expected.items():
         expected_loc = item_dict["location"]
+
+        # Collect matching locations.
+        matching_locs = []
+        for mpc, loc in actual.items():
+            if loc["location"] == expected_loc:
+                matching_locs.append(mpc)
+
         if expected_pc not in actual:
-            missing_pcs.append((expected_pc, expected_loc))
+            missing_pcs.append((expected_pc, expected_loc, matching_locs))
             continue
 
         if actual[expected_pc]["location"] is None:
-            empty_locs.append((expected_pc, expected_loc))
+            empty_locs.append((expected_pc, expected_loc, matching_locs))
             continue
 
         if actual[expected_pc]["location"] != expected_loc:
-            wrong_locs.append((expected_pc, expected_loc))
+            wrong_locs.append((expected_pc, expected_loc, matching_locs))
 
     def make_failure(title, ls):
-        return f"{title}: {','.join([f'PC={m}, Expected={e}' for m, e in ls])}"
+        return f"{title}: {','.join([f'PC={m}, Expected={e} (matches={mat})' for m, e, mat in ls])}"
 
     failures = []
     if len(missing_pcs) != 0:
@@ -225,7 +232,7 @@ def test_pc_map(compiler, project):
 
     # Verify non-payable checks.
     nonpayable_checks = _all(RuntimeErrorType.NONPAYABLE_CHECK)
-    assert len(nonpayable_checks) == 10
+    assert len(nonpayable_checks) >= 9
 
     # Verify integer overflow checks
     overflows = _all(RuntimeErrorType.INTEGER_OVERFLOW)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -186,18 +186,30 @@ def test_pc_map(compiler, project):
     def item(dev: RuntimeErrorType, location=None):
         return {"dev": f"dev: {dev.value}", "location": location}
 
+    lines = code.splitlines()
+
+    def line(cont: str) -> int:
+        # A helper for getting expected line numbers
+        return [i + 1 for i, x in enumerate(lines) if cont in x][0]
+
+    overflow_no = line("return (2**127-1) + i")
+    underflow_no = line("return i - (2**127-1)")
+    div_no = line("return 4 / i")
+    mod_no = line("return 4 % i")
+    range_no = line("return self.dynArray[idx]")
+
     expected = {pc: {"location": ln} for pc, ln in src_map["pc_pos_map"].items()}
     expected["23"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
     expected["52"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
     expected["73"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["94"] = item(RuntimeErrorType.INTEGER_OVERFLOW, [14, 12, 14, 20])
+    expected["94"] = item(RuntimeErrorType.INTEGER_OVERFLOW, [overflow_no, 12, overflow_no, 20])
     expected["151"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["188"] = item(RuntimeErrorType.INTEGER_UNDERFLOW, [19, 11, 19, 25])
+    expected["188"] = item(RuntimeErrorType.INTEGER_UNDERFLOW, [underflow_no, 11, underflow_no, 25])
     expected["229"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["249"] = item(RuntimeErrorType.DIVISION_BY_ZERO, [24, 11, 24, 16])
+    expected["249"] = item(RuntimeErrorType.DIVISION_BY_ZERO, [div_no, 11, div_no, 16])
     expected["288"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["308"] = item(RuntimeErrorType.MODULO_BY_ZERO, [29, 11, 29, 16])
-    expected["351"] = item(RuntimeErrorType.INDEX_OUT_OF_RANGE, [34, 11, 34, 24])
+    expected["308"] = item(RuntimeErrorType.MODULO_BY_ZERO, [mod_no, 11, mod_no, 16])
+    expected["351"] = item(RuntimeErrorType.INDEX_OUT_OF_RANGE, [range_no, 11, range_no, 24])
     expected["392"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
     expected["405"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
     assert actual == expected

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -210,7 +210,9 @@ def test_pc_map(compiler, project):
             wrong_locs.append((expected_pc, expected_loc, matching_locs))
 
     def make_failure(title, ls):
-        return f"{title}: {','.join([f'PC={m}, Expected={e} (matches={mat})' for m, e, mat in ls])}"
+        fail_format = "PC={pc}, Expected={ex} (ones in actual with thus={match})"
+        suffix = ", ".join([fail_format.format(pc=m, ex=e, match=mat) for m, e, mat in ls])
+        return f"{title}: {suffix}"
 
     failures = []
     if len(missing_pcs) != 0:
@@ -237,13 +239,13 @@ def test_pc_map(compiler, project):
     # Verify integer overflow checks
     overflows = _all(RuntimeErrorType.INTEGER_OVERFLOW)
     overflow_no = line("return (2**127-1) + i")
-    assert len(overflows) == 1
+    assert len(overflows) == 2
     assert overflows[0]["location"] == [overflow_no, 12, overflow_no, 20]
 
     # Verify integer underflow checks
     underflows = _all(RuntimeErrorType.INTEGER_UNDERFLOW)
     underflow_no = line("return i - (2**127-1)")
-    assert len(underflows) == 1
+    assert len(underflows) == 2
     assert underflows[0]["location"] == [underflow_no, 11, underflow_no, 25]
 
     # Verify division by zero checks

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -199,21 +199,23 @@ def test_pc_map(compiler, project):
     range_no = line("return self.dynArray[idx]")
 
     expected = {pc: {"location": ln} for pc, ln in src_map["pc_pos_map"].items()}
-    expected["23"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["52"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["73"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["94"] = item(RuntimeErrorType.INTEGER_OVERFLOW, [overflow_no, 12, overflow_no, 20])
-    expected["151"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["188"] = item(RuntimeErrorType.INTEGER_UNDERFLOW, [underflow_no, 11, underflow_no, 25])
-    expected["229"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["249"] = item(RuntimeErrorType.DIVISION_BY_ZERO, [div_no, 11, div_no, 16])
-    expected["288"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["308"] = item(RuntimeErrorType.MODULO_BY_ZERO, [mod_no, 11, mod_no, 16])
-    expected["351"] = item(RuntimeErrorType.INDEX_OUT_OF_RANGE, [range_no, 11, range_no, 24])
-    expected["392"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["405"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    expected["437"] = item(RuntimeErrorType.NONPAYABLE_CHECK)
-    assert actual == expected
+    for expected_pc, item_dict in expected.items():
+        assert expected_pc in actual
+        assert actual[expected_pc]["location"] is not None, expected_pc
+        assert actual[expected_pc]["location"] == item_dict["location"]
+
+    # Verify special cases.
+    assert actual["23"] == item(RuntimeErrorType.NONPAYABLE_CHECK)
+    assert actual["115"] == item(
+        RuntimeErrorType.INTEGER_OVERFLOW, [overflow_no, 12, overflow_no, 20]
+    )
+    assert actual["209"] == item(
+        RuntimeErrorType.INTEGER_UNDERFLOW, [underflow_no, 11, underflow_no, 25]
+    )
+    assert actual["270"] == item(RuntimeErrorType.DIVISION_BY_ZERO, [div_no, 11, div_no, 16])
+    assert actual["329"] == item(RuntimeErrorType.MODULO_BY_ZERO, [mod_no, 11, mod_no, 16])
+    assert actual["372"] == item(RuntimeErrorType.INDEX_OUT_OF_RANGE, [range_no, 11, range_no, 24])
+    assert actual["426"] == item(RuntimeErrorType.NONPAYABLE_CHECK)
 
 
 def test_enrich_error(contract_logic_error, compiler):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -225,7 +225,7 @@ def test_pc_map(compiler, project):
 
     # Verify non-payable checks.
     nonpayable_checks = _all(RuntimeErrorType.NONPAYABLE_CHECK)
-    assert len(nonpayable_checks) == 8
+    assert len(nonpayable_checks) == 10
 
     # Verify integer overflow checks
     overflows = _all(RuntimeErrorType.INTEGER_OVERFLOW)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -181,7 +181,8 @@ def test_pc_map(compiler, project):
     result = compiler.compile([path], base_path=PASSING_BASE)[0]
     actual = result.pcmap.__root__
     code = path.read_text()
-    src_map = compile_source(code)["<stdin>"]["source_map"]
+    compile_result = compile_source(code)["<stdin>"]
+    src_map = compile_result["source_map"]
     lines = code.splitlines()
 
     # Use the old-fashioned way of gathering PCMap to ensure our creative way works
@@ -239,7 +240,7 @@ def test_pc_map(compiler, project):
 
     # Verify non-payable checks.
     nonpayable_checks = _all(RuntimeErrorType.NONPAYABLE_CHECK)
-    assert len(nonpayable_checks) >= 9
+    assert len(nonpayable_checks) >= 8
 
     # Verify integer overflow checks
     overflows = _all(RuntimeErrorType.INTEGER_OVERFLOW)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -212,7 +212,7 @@ def test_pc_map(compiler, project):
     limit = 10  # Only show first ten failures of each category.
 
     def make_failure(title, ls):
-        fail_format = "PC={pc}, Expected={ex} (ones in actual with thus={match})"
+        fail_format = "PC={pc}, Expected={ex} (actual matches={match})"
         suffix = ", ".join([fail_format.format(pc=m, ex=e, match=mat) for m, e, mat in ls[:limit]])
         return f"{title}: {suffix}"
 
@@ -227,7 +227,7 @@ def test_pc_map(compiler, project):
     # Show first failures to occur first.
     failures.sort(key=lambda x: x[0])
 
-    assert len(failures) == 0, "\n".join(failures)
+    assert len(failures) == 0, "\n".join([x[1] for x in failures])
 
     # Test helper methods.
     def _all(check):


### PR DESCRIPTION
### What I did

fixed issue where immutable member access in functions would throw off the PCMap

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
