### PR TITLE
fix: enrich error when dev message is name of runtime error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     url="https://github.com/ApeWorX/ape-vyper",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.10,<0.7",
+        "eth-ape>=0.6.11,<0.7",
         "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.1.0,<0.2",

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -328,7 +328,6 @@ def test_enrich_error_non_payable_check(geth_provider, traceback_contract_037, a
         traceback_contract_037.addBalance(123, sender=account, value=1)
 
 
-@pytest.mark.skipif(APE_VERSION <= Version("0.6.10"), reason="Fallback invoked via new API")
 def test_enrich_error_fallback(geth_provider, traceback_contract_037, account):
     """
     Show that when attempting to call a contract's fallback method when there is
@@ -336,6 +335,18 @@ def test_enrich_error_fallback(geth_provider, traceback_contract_037, account):
     """
     with pytest.raises(FallbackNotDefinedError):
         traceback_contract_037(sender=account)
+
+
+def test_enrich_error_handle_when_name(compiler, geth_provider):
+    """
+    Sometimes, a provider may use the name of the enum instead of the value,
+    which we are still able to enrich.
+    """
+
+    error = ContractLogicError("")
+    error.__dict__["dev_message"] = "dev: NONPAYABLE_CHECK"
+    new_error = compiler.enrich_error(error)
+    assert isinstance(new_error, NonPayableError)
 
 
 def test_trace_source(account, geth_provider, project, traceback_contract):
@@ -397,7 +408,6 @@ Traceback (most recent call last)
     assert str(actual) == expected
 
 
-@pytest.mark.skipif(APE_VERSION <= Version("0.6.10"), reason="Fallback invoked via new API")
 def test_trace_source_default_method(geth_provider, account, project):
     """
     This test proves you get a working source-traceback from __default__ calls.


### PR DESCRIPTION
### What I did

Ran into a case where hardhat gave me this for some reason, maybe in ape-hardhat a bug but idk, shouldnt really matter, still able to enrich

### How I did it

check if name of enum, use that one

### How to verify it

things still workin as normal is good nuff, but i did add a test as well

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
