### PR TITLE
fix: empty contract [APE-1129]

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -599,6 +599,9 @@ def _get_pcmap(bytecode: Dict, src_map: List[SourceMapItem], opcodes: List[str])
     # Find the non payable value check.
     src_info = bytecode["sourceMapFull"]
     pc_data = {pc: {"location": ln} for pc, ln in src_info["pc_pos_map"].items()}
+    if not pc_data:
+        return PCMap.parse_obj({})
+
     non_payable_check = _find_non_payable_check(src_map, opcodes)
     if not non_payable_check:
         non_payable_check = min([int(x) for x in pc_data]) - 1

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -108,13 +108,14 @@ def test_get_version_map(project, compiler):
         pytest.fail(fail_message)
 
     assert len(actual[OLDER_VERSION_FROM_PRAGMA]) == 1
-    assert len(actual[VERSION_FROM_PRAGMA]) == 8
+    assert len(actual[VERSION_FROM_PRAGMA]) == 9
     assert actual[OLDER_VERSION_FROM_PRAGMA] == {project.contracts_folder / "older_version.vy"}
 
     expected = (
         "contract.vy",
         "contract_no_pragma.vy",
         "contract_with_dev_messages.vy",
+        "empty.vy",
         "erc20.vy",
         "registry_039.vy",
         "traceback_contract_039.vy",
@@ -155,7 +156,7 @@ def test_compiler_data_in_manifest(project):
     for compiler in (vyper_028, vyper_latest):
         assert compiler.name == "vyper"
 
-    assert len(vyper_latest.contractTypes) == 8
+    assert len(vyper_latest.contractTypes) == 9
     assert len(vyper_028.contractTypes) == 1
     assert "contract" in vyper_latest.contractTypes
     assert "older_version" in vyper_028.contractTypes


### PR DESCRIPTION
### What I did

Issue prevent ing empty contracts from compiling

### How I did it

an early return in PCMap generation

### How to verify it

compile an empty file with a `.vy` suffix

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
