### PR TITLE
fix: remove upper pin on vyper dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.2.0,<0.3",
-        "vyper~=0.3.7",
+        "vyper>=0.3.7",  # Purposely no upper-pin.
     ],
     python_requires=">=3.9,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

trying to assist in envs where vyper is installed in 0.4

fixes: #114
fixes APE-1762

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
