### PR TITLE
feat: Vyper 0.4 flattener

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -276,6 +276,77 @@ def get_evm_version_pragma_map(
     return pragmas
 
 
+def _lookup_source_from_site_packages(
+    dependency_name: str,
+    filestem: str,
+    config_override: Optional[dict] = None,
+) -> Optional[tuple[Path, ProjectManager]]:
+    # Attempt looking up dependency from site-packages.
+    config_override = config_override or {}
+    if "contracts_folder" not in config_override:
+        # Default to looking through the whole release for
+        # contracts. Most often, Python-based dependencies publish
+        # only their contracts this way, and we are only looking
+        # for sources so accurate project configuration is not required.
+        config_override["contracts_folder"] = "."
+
+    try:
+        imported_project = ProjectManager.from_python_library(
+            dependency_name,
+            config_override=config_override,
+        )
+    except ProjectError as err:
+        # Still attempt to let Vyper handle this during compilation.
+        logger.error(
+            f"'{dependency_name}' may not be installed. "
+            "Could not find it in Ape dependencies or Python's site-packages. "
+            f"Error: {err}"
+        )
+    else:
+        extensions = [*[f"{t}" for t in FileType], ".json"]
+
+        def seek() -> Optional[Path]:
+            for ext in extensions:
+                try_source_id = f"{filestem}{ext}"
+                if source_path := imported_project.sources.lookup(try_source_id):
+                    return source_path
+
+            return None
+
+        if res := seek():
+            return res, imported_project
+
+        # Still not found. Try again without contracts_folder set.
+        # This will attempt to use Ape's contracts_folder detection system.
+        # However, I am not sure this situation occurs, as Vyper-python
+        # based dependencies are new at the time of writing this.
+        new_override = config_override or {}
+        if "contracts_folder" in new_override:
+            del new_override["contracts_folder"]
+
+        imported_project.reconfigure(**new_override)
+        if res := seek():
+            return res, imported_project
+
+        # Still not found. Log a very helpful message.
+        existing_filestems = [f.stem for f in imported_project.path.iterdir()]
+        fs_str = ", ".join(existing_filestems)
+        contracts_folder = imported_project.contracts_folder
+        path = imported_project.path
+
+        # This will log the calculated / user-set contracts_folder.
+        contracts_path = f"{get_relative_path(contracts_folder, path)}"
+
+        logger.error(
+            f"Source for stem '{filestem}' not found in "
+            f"'{imported_project.path}'."
+            f"Contracts folder: {contracts_path}, "
+            f"Existing file(s): {fs_str}"
+        )
+
+    return None
+
+
 class VyperCompiler(CompilerAPI):
     @property
     def name(self) -> str:
@@ -397,9 +468,9 @@ class VyperCompiler(CompilerAPI):
 
                                     is_local = False
                                     break
-                    else:
+                    elif dependency_name:
                         # Attempt looking up dependency from site-packages.
-                        if res := self._lookup_source_from_site_packages(dependency_name, filestem):
+                        if res := _lookup_source_from_site_packages(dependency_name, filestem):
                             source_path, imported_project = res
                             import_source_id = str(source_path)
                             # Also include imports of imports.
@@ -429,77 +500,6 @@ class VyperCompiler(CompilerAPI):
                     import_map[source_id].append(import_source_id)
 
         return dict(import_map)
-
-    def _lookup_source_from_site_packages(
-        self,
-        dependency_name: str,
-        filestem: str,
-        config_override: Optional[dict] = None,
-    ) -> Optional[tuple[Path, ProjectManager]]:
-        # Attempt looking up dependency from site-packages.
-        config_override = config_override or {}
-        if "contracts_folder" not in config_override:
-            # Default to looking through the whole release for
-            # contracts. Most often, Python-based dependencies publish
-            # only their contracts this way, and we are only looking
-            # for sources so accurate project configuration is not required.
-            config_override["contracts_folder"] = "."
-
-        try:
-            imported_project = ProjectManager.from_python_library(
-                dependency_name,
-                config_override=config_override,
-            )
-        except ProjectError as err:
-            # Still attempt to let Vyper handle this during compilation.
-            logger.error(
-                f"'{dependency_name}' may not be installed. "
-                "Could not find it in Ape dependencies or Python's site-packages. "
-                f"Error: {err}"
-            )
-        else:
-            extensions = [*[f"{t}" for t in FileType], ".json"]
-
-            def seek() -> Optional[Path]:
-                for ext in extensions:
-                    try_source_id = f"{filestem}{ext}"
-                    if source_path := imported_project.sources.lookup(try_source_id):
-                        return source_path
-
-                return None
-
-            if res := seek():
-                return res, imported_project
-
-            # Still not found. Try again without contracts_folder set.
-            # This will attempt to use Ape's contracts_folder detection system.
-            # However, I am not sure this situation occurs, as Vyper-python
-            # based dependencies are new at the time of writing this.
-            new_override = config_override or {}
-            if "contracts_folder" in new_override:
-                del new_override["contracts_folder"]
-
-            imported_project.reconfigure(**new_override)
-            if res := seek():
-                return res, imported_project
-
-            # Still not found. Log a very helpful message.
-            existing_filestems = [f.stem for f in imported_project.path.iterdir()]
-            fs_str = ", ".join(existing_filestems)
-            contracts_folder = imported_project.contracts_folder
-            path = imported_project.path
-
-            # This will log the calculated / user-set contracts_folder.
-            contracts_path = f"{get_relative_path(contracts_folder, path)}"
-
-            logger.error(
-                f"Source for stem '{filestem}' not found in "
-                f"'{imported_project.path}'."
-                f"Contracts folder: {contracts_path}, "
-                f"Existing file(s): {fs_str}"
-            )
-
-        return None
 
     def get_versions(self, all_paths: Iterable[Path]) -> set[str]:
         versions = set()
@@ -1063,7 +1063,7 @@ class VyperCompiler(CompilerAPI):
                 else:
                     # Vyper <0.4 interface from folder other than interfaces/
                     # such as a .vyi file in the contracts folder.
-                    abis = source_to_abi(import_file.read_text())
+                    abis = source_to_abi(import_file.read_text(encoding="utf8"))
                     interfaces_source += generate_interface(abis, iface_name)
 
         def no_nones(it: Iterable[Optional[str]]) -> Iterable[str]:
@@ -1092,6 +1092,27 @@ class VyperCompiler(CompilerAPI):
             # Replace usage lines like 'zero_four_module.moduleMethod()'
             # with 'self.moduleMethod()'.
             flattened_source = flattened_source.replace(f"{prefix}.", "self.")
+
+        # Remove module-level doc-strings, as it causes compilation issues
+        # when used in root contracts.
+        lines_no_doc: list[str] = []
+        in_str_comment = False
+        for line in flattened_source.splitlines():
+            line_stripped = line.rstrip()
+            if not in_str_comment and line_stripped.startswith('"""'):
+                if line_stripped == '"""' or not line_stripped.endswith('"""'):
+                    in_str_comment = True
+                continue
+
+            elif in_str_comment:
+                if line_stripped.endswith('"""'):
+                    in_str_comment = False
+
+                continue
+
+            lines_no_doc.append(line)
+
+        flattened_source = "\n".join(lines_no_doc)
 
         # TODO: Replace this nonsense with a real code formatter
         def format_source(source: str) -> str:
@@ -1275,6 +1296,7 @@ class VyperCompiler(CompilerAPI):
                     optimization = False
 
                 if version >= Version("0.4.0"):
+
                     def _to_src_id(s):
                         return str(pm.path / s) if use_absolute_path else s
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -380,7 +380,11 @@ class VyperCompiler(CompilerAPI):
                 continue
 
             content = path.read_text().splitlines()
-            source_id = str(get_relative_path(path.absolute(), pm.path.absolute()))
+            source_id = (
+                str(path.absolute())
+                if use_absolute_paths
+                else str(get_relative_path(path.absolute(), pm.path.absolute()))
+            )
 
             # Prevent infinitely handling imports when they cross over.
             if source_id in handled:

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -973,6 +973,7 @@ class VyperCompiler(CompilerAPI):
         project: Optional[ProjectManager] = None,
         include_pragma: bool = True,
         sources_handled: Optional[set[Path]] = None,
+        warn_flattening_modules: bool = True,
     ) -> str:
         pm = project or self.local_project
         handled = sources_handled or set()
@@ -1052,6 +1053,13 @@ class VyperCompiler(CompilerAPI):
                     and version_specifier.contains("0.4.0")
                     and import_file.suffix != ".vyi"
                 ):
+                    if warn_flattening_modules:
+                        logger.warning(
+                            "Flattening modules DOES NOT yield the same bytecode! "
+                            "This is **NOT** valid for contract-verification."
+                        )
+                        warn_flattening_modules = False
+
                     modules_prefixes.add(import_file.stem)
                     if import_file in handled:
                         # We have already included this source somewhere.
@@ -1060,7 +1068,10 @@ class VyperCompiler(CompilerAPI):
                     # Is a module or an interface imported from a module.
                     # Copy in the source code directly.
                     flattened_module = self._flatten_source(
-                        import_file, include_pragma=False, sources_handled=handled
+                        import_file,
+                        include_pragma=False,
+                        sources_handled=handled,
+                        warn_flattening_modules=warn_flattening_modules,
                     )
                     flattened_modules = f"{flattened_modules}\n\n{flattened_module}"
 

--- a/ape_vyper/interface.py
+++ b/ape_vyper/interface.py
@@ -2,7 +2,6 @@
 Tools for working with ABI specs and Vyper interface source code
 """
 
-from pathlib import Path
 from typing import Any, Optional, Union
 
 from ethpm_types import ABI, MethodABI
@@ -15,11 +14,6 @@ INDENT = " " * INDENT_SPACES
 def indent_line(line: str, level=1) -> str:
     """Indent a source line of code"""
     return f"{INDENT * level}{line}"
-
-
-def iface_name_from_file(fpath: Path) -> str:
-    """Get Interface name from file path"""
-    return fpath.name.split(".")[0]
 
 
 def generate_inputs(inputs: list[ABIType]) -> str:
@@ -71,7 +65,7 @@ def generate_interface(abi: Union[list[dict[str, Any]], list[ABI]], iface_name: 
 
 
 def extract_meta(source_code: str) -> tuple[Optional[str], str]:
-    """Extract version pragma, and returne cleaned source"""
+    """Extract version pragma, and return cleaned source"""
     version_pragma: Optional[str] = None
     cleaned_source_lines: list[str] = []
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "ethpm-types",  # Use same version as eth-ape
         "tqdm",  # Use same version as eth-ape
         "vvm>=0.2.0,<0.3",
-        "vyper~=0.3.7",
+        "vyper>=0.3.7,<0.5",
     ],
     python_requires=">=3.10,<4",
     extras_require=extras_require,

--- a/tests/contracts/passing_contracts/zero_four.vy
+++ b/tests/contracts/passing_contracts/zero_four.vy
@@ -11,6 +11,10 @@ from snekmate.auth import ownable
 # (new in Vyper 0.4).
 from ethereum.ercs import IERC20
 
+# `zero_four_module.vy` also imports this next line.
+# We are testing that the flattener can handle that.
+from . import zero_four_module_2 as zero_four_module_2
+
 @external
 @view
 def implementThisPlease(role: bytes32) -> bool:
@@ -20,3 +24,8 @@ def implementThisPlease(role: bytes32) -> bool:
 @external
 def callModuleFunction(role: bytes32) -> bool:
     return zero_four_module.moduleMethod()
+
+
+@external
+def callModule2Function(role: bytes32) -> bool:
+    return zero_four_module_2.moduleMethod2()

--- a/tests/contracts/passing_contracts/zero_four_module.vy
+++ b/tests/contracts/passing_contracts/zero_four_module.vy
@@ -1,5 +1,14 @@
 # pragma version ~=0.4.0
 
+# This source is also imported from `zero_four.py` to test
+# multiple imports across sources during flattening.
+from . import zero_four_module_2 as zero_four_module_2
+
 @internal
 def moduleMethod() -> bool:
     return True
+
+
+@external
+def callModule2FunctionFromAnotherSource(role: bytes32) -> bool:
+    return zero_four_module_2.moduleMethod2()

--- a/tests/contracts/passing_contracts/zero_four_module_2.vy
+++ b/tests/contracts/passing_contracts/zero_four_module_2.vy
@@ -1,0 +1,9 @@
+# pragma version ~=0.4.0
+
+# Showing importing interface from module.
+interface Ballot:
+    def delegated(addr: address) -> bool: view
+
+@internal
+def moduleMethod2() -> bool:
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ from ape_vyper._cli import cli
         ),
     ],
 )
-def test_cli_flatten(project, contract_name, expected, cli_runner):
+def test_flatten(project, contract_name, expected, cli_runner):
     path = project.contracts_folder / contract_name
     arguments = ["flatten", str(path)]
     end = ("--project", str(project.path))

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -53,6 +53,83 @@ interface IFaceZeroFour:
     def implementThisPlease(role: bytes32) -> bool: view
 
 
+# @dev Returns the address of the current owner.
+# @notice If you declare a variable as `public`,
+# Vyper automatically generates an `external`
+# getter function for the variable.
+owner: public(address)
+
+
+# @dev Emitted when the ownership is transferred
+# from `previous_owner` to `new_owner`.
+event OwnershipTransferred:
+    previous_owner: indexed(address)
+    new_owner: indexed(address)
+
+
+@deploy
+@payable
+def __init__():
+    \"\"\"
+    @dev To omit the opcodes for checking the `msg.value`
+         in the creation-time EVM bytecode, the constructor
+         is declared as `payable`.
+    @notice The `owner` role will be assigned to
+            the `msg.sender`.
+    \"\"\"
+    self._transfer_ownership(msg.sender)
+
+
+@external
+def transfer_ownership(new_owner: address):
+    \"\"\"
+    @dev Transfers the ownership of the contract
+         to a new account `new_owner`.
+    @notice Note that this function can only be
+            called by the current `owner`. Also,
+            the `new_owner` cannot be the zero address.
+    @param new_owner The 20-byte address of the new owner.
+    \"\"\"
+    self._check_owner()
+    assert new_owner != empty(address), "ownable: new owner is the zero address"
+    self._transfer_ownership(new_owner)
+
+
+@external
+def renounce_ownership():
+    \"\"\"
+    @dev Leaves the contract without an owner.
+    @notice Renouncing ownership will leave the
+            contract without an owner, thereby
+            removing any functionality that is
+            only available to the owner.
+    \"\"\"
+    self._check_owner()
+    self._transfer_ownership(empty(address))
+
+
+@internal
+def _check_owner():
+    \"\"\"
+    @dev Throws if the sender is not the owner.
+    \"\"\"
+    assert msg.sender == self.owner, "ownable: caller is not the owner"
+
+
+@internal
+def _transfer_ownership(new_owner: address):
+    \"\"\"
+    @dev Transfers the ownership of the contract
+         to a new account `new_owner`.
+    @notice This is an `internal` function without
+            access restriction.
+    @param new_owner The 20-byte address of the new owner.
+    \"\"\"
+    old_owner: address = self.owner
+    self.owner = new_owner
+    log OwnershipTransferred(old_owner, new_owner)
+
+
 # This source is also imported from `zero_four.py` to test
 # multiple imports across sources during flattening.
 
@@ -77,6 +154,9 @@ def moduleMethod2() -> bool:
 
 implements: IFaceZeroFour
 
+
+# Also show we can import from ethereum namespace.
+# (new in Vyper 0.4).
 
 # `self.vy` also imports this next line.
 # We are testing that the flattener can handle that.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -297,7 +297,13 @@ def test_get_version_map(project, compiler, all_versions):
 
     # Vyper 0.4.0 assertions.
     actual4 = {x.name for x in actual[VERSION_04]}
-    expected4 = {"contract_no_pragma.vy", "empty.vy", "zero_four_module.vy", "zero_four.vy"}
+    expected4 = {
+        "contract_no_pragma.vy",
+        "empty.vy",
+        "zero_four.vy",
+        "zero_four_module.vy",
+        "zero_four_module_2.vy",
+    }
     assert actual4 == expected4
 
 


### PR DESCRIPTION
### What I did

Adds the ability to flatten vyper 0.4 contracts via bumping vyper and handling module-imports

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
