### PR TITLE
fix: interfaces import

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -410,7 +410,7 @@ class VyperCompiler(CompilerAPI):
                     dots += prefix[0]
                     prefix = prefix[1:]
 
-                is_relative = dots != ""
+                is_relative = dots != "" or prefix.startswith("interfaces")
 
                 # Replace rest of dots with slashes.
                 prefix = prefix.replace(".", os.path.sep)


### PR DESCRIPTION
### What I did
Fixes local importing of `interfaces` directory not being recognized as a local directory. 
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #125 

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
