### PR TITLE
fix: compile ABI-based dependencies at better time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,18 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.11.2
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic==1.10.4]

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -668,16 +668,6 @@ class VyperCompiler(CompilerAPI):
                 continue
 
             handled.add(dep_id)
-
-            try:
-                dependency.compile()
-            except Exception as err:
-                logger.warning(
-                    f"Failed to compile dependency '{dependency.name}' @ '{dependency.version}'.\n"
-                    f"Reason: {err}"
-                )
-                continue
-
             dependencies[remapping.key] = dependency.project
 
         # Add auto-remapped dependencies.
@@ -689,16 +679,6 @@ class VyperCompiler(CompilerAPI):
                 continue
 
             handled.add(dep_id)
-
-            try:
-                dependency.compile()
-            except Exception as err:
-                logger.warning(
-                    f"Failed to compile dependency '{dependency.name}' @ '{dependency.version}'.\n"
-                    f"Reason: {err}"
-                )
-                continue
-
             dependencies[dependency.name] = dependency.project
 
         return dependencies

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -507,8 +507,8 @@ class VyperCompiler(CompilerAPI):
                                 if f"{source_id_stem}{ext}" in dep_project.sources:
                                     # Dependency located.
                                     if not dependency.project.manifest.contract_types:
-                                        # In this case, the dependency *must* be compiled so the ABIs
-                                        # can be found later on.
+                                        # In this case, the dependency *must* be compiled
+                                        # so the ABIs can be found later on.
                                         try:
                                             dependency.compile()
                                         except Exception as err:
@@ -516,7 +516,8 @@ class VyperCompiler(CompilerAPI):
                                             # a better error from the Vyper compiler, in case
                                             # something else is wrong.
                                             logger.warning(
-                                                f"Failed to compile dependency '{dependency.name}' @ '{dependency.version}'.\n"
+                                                f"Failed to compile dependency '{dependency.name}' "
+                                                f"@ '{dependency.version}'.\n"
                                                 f"Reason: {err}"
                                             )
 

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -510,7 +510,7 @@ class VyperCompiler(CompilerAPI):
                             is_local = False
                             found = True
 
-                    elif not found and dep_key in dependencies:
+                    if not found and dep_key in dependencies:
                         for version_str, dep_project in pm.dependencies[dependency_name].items():
                             dependency = pm.dependencies.get_dependency(
                                 dependency_name, version_str

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ extras_require = {
         "snekmate",  # Python package-sources integration testing
     ],
     "lint": [
-        "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.11.0,<2",  # Static type analyzer
+        "black>=24.8.0,<25",  # Auto-formatter and linter
+        "mypy>=1.11.2,<2",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
-        "flake8>=7.1.0,<8",  # Style linter
+        "flake8>=7.1.1,<8",  # Style linter
         "isort>=5.13.2",  # Import sorting linter
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -5,3 +5,10 @@ contracts_folder: contracts/passing_contracts
 dependencies:
   - name: exampledependency
     local: ./ExampleDependency
+
+  # NOTE: Snekmate does not need to be listed here since
+  # it is installed in site-packages. However, we include it
+  # to show it doesn't cause problems when included.
+  - python: snekmate
+    config_override:
+      contracts_folder: .


### PR DESCRIPTION
### What I did

Using dependencies like snekmate for Vyper 0.4 was annoying because Vyper 0.3 range dependencies required being compiled for their abis but not in 0.4 so it is a difficult balance.

This PR compiles ABI-based dependencies at a more apt time, when we are further aware that they are indeed ABI-based dependencies and not site-package based or something else.

### How I did it

move stuff around

### How to verify it

Use snekmate via config like this:

```yaml
dependencies:
   - python: snekmate
     config_override:
       contracts_folder: .
```

Use something in the Token.vy like @Ninjagod1251 did.

compile

```sh
ape compile
```

Should not see warning anymore.
Also it compiles much faster and is cleaner

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
