### PR TITLE
fix: issue where `compile_code` was creating a file

### DIFF
--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -985,16 +985,16 @@ class VyperCompiler(CompilerAPI):
         #   Vyper in our tests because of the monkeypatch. Also, their approach
         #   isn't really different than our approach implemented below.
         pm = project or self.local_project
-        with pm.isolate_in_tempdir():
+        with pm.isolate_in_tempdir() as tmp_project:
             name = kwargs.get("contractName", "code")
-            file = pm.path / f"{name}.vy"
+            file = tmp_project.path / f"{name}.vy"
             file.write_text(code, encoding="utf8")
-            contract_type = next(self.compile((file,), project=pm), None)
+            contract_type = next(self.compile((file,), project=tmp_project), None)
             if contract_type is None:
                 # Not sure when this would happen.
                 raise VyperCompileError("Failed to produce contract type.")
 
-            # Clean-up (just in case)
+            # Clean-up (just in case tmp_project is re-used)
             file.unlink(missing_ok=True)
 
             return contract_type

--- a/ape_vyper/compiler.py
+++ b/ape_vyper/compiler.py
@@ -994,6 +994,9 @@ class VyperCompiler(CompilerAPI):
                 # Not sure when this would happen.
                 raise VyperCompileError("Failed to produce contract type.")
 
+            # Clean-up (just in case)
+            file.unlink(missing_ok=True)
+
             return contract_type
 
     def _source_vyper_version(self, code: str) -> Version:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -566,7 +566,7 @@ def test_enrich_error_handle_when_name(compiler, geth_provider, mocker):
 
     tb = mocker.MagicMock()
     tb.revert_type = "NONPAYABLE_CHECK"
-    error = ContractLogicError("", source_traceback=tb)
+    error = ContractLogicError(None, source_traceback=tb)
     new_error = compiler.enrich_error(error)
     assert isinstance(new_error, NonPayableError)
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,10 +1,12 @@
 import re
 from pathlib import Path
+from typing import Optional
 
 import ape
 import pytest
 import vvm  # type: ignore
 from ape.exceptions import CompilerError, ContractLogicError
+from ape.types import SourceTraceback
 from ape.utils import get_full_extension
 from ethpm_types import ContractType
 from packaging.version import Version
@@ -563,9 +565,12 @@ def test_enrich_error_handle_when_name(compiler, geth_provider, mocker):
     Sometimes, a provider may use the name of the enum instead of the value,
     which we are still able to enrich.
     """
+    class TB(SourceTraceback):
+        @property
+        def revert_type(self) -> Optional[str]:
+            return "NONPAYABLE_CHECK"
 
-    tb = mocker.MagicMock()
-    tb.revert_type = "NONPAYABLE_CHECK"
+    tb = TB([{"statements": [], "closure": {"name": "fn"}, "depth": 0}])  # type: ignore
     error = ContractLogicError(None, source_traceback=tb)
     new_error = compiler.enrich_error(error)
     assert isinstance(new_error, NonPayableError)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -565,6 +565,7 @@ def test_enrich_error_handle_when_name(compiler, geth_provider, mocker):
     Sometimes, a provider may use the name of the enum instead of the value,
     which we are still able to enrich.
     """
+
     class TB(SourceTraceback):
         @property
         def revert_type(self) -> Optional[str]:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -689,6 +689,10 @@ def test_compile_code(project, compiler, dev_revert_source):
     assert len(actual.deployment_bytecode.bytecode) > 1
     assert len(actual.runtime_bytecode.bytecode) > 1
 
+    # Ensure temp-file was deleted.
+    file = project.path / "MyContract.vy"
+    assert not file.is_file()
+
 
 def test_compile_with_version_set_in_settings_dict(config, compiler_manager, projects_path):
     path = projects_path / "version_in_config"


### PR DESCRIPTION
### What I did

compile_code was not using the temp project, and thus creating a file locally that never got cleaned up.
this pr:

1. actually uses the temp project (main issue fix)
2. cleans up file anyways, just in case!
3. fixes a failing test (not a bug just the setup needed adjusting)

also if you are reviewing this PR, please also review this one: https://github.com/ApeWorX/ape-vyper/pull/130 which is important

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
