### PR TITLE
feat: add support for `enable_decimals` for Vyper 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ Import the voting contract types like this:
 import voting.ballot as ballot
 ```
 
+### Decimals
+
+To use decimals on Vyper 0.4, use the following config:
+
+```yaml
+vyper:
+  enable_decimals: true
+```
+
 ### Pragmas
 
 Ape-Vyper supports Vyper 0.3.10's [new pragma formats](https://github.com/vyperlang/vyper/pull/3493)

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,10 +1,10 @@
 # Allows compiling to work from the project-level.
-contracts_folder: contracts/passing_contracts
+contracts_folder: tests/contracts/passing_contracts
 
 # Specify a dependency to use in Vyper imports.
 dependencies:
   - name: exampledependency
-    local: ./ExampleDependency
+    local: ./tests/ExampleDependency
 
   # NOTE: Snekmate does not need to be listed here since
   # it is installed in site-packages. However, we include it
@@ -12,3 +12,6 @@ dependencies:
   - python: snekmate
     config_override:
       contracts_folder: .
+
+vyper:
+  enable_decimals: true

--- a/ape_vyper/compiler/_versions/base.py
+++ b/ape_vyper/compiler/_versions/base.py
@@ -190,8 +190,7 @@ class BaseVyperCompiler(ManagerAccessMixin):
                 optimization = False
 
             selection_dict = self._get_selection_dictionary(selection, project=pm)
-            search_paths = [*getsitepackages()]
-            search_paths.append(".")
+            search_paths = [*getsitepackages(), "."]
 
             version_settings[settings_key] = {
                 "optimize": optimization,

--- a/ape_vyper/compiler/_versions/vyper_04.py
+++ b/ape_vyper/compiler/_versions/vyper_04.py
@@ -23,6 +23,25 @@ class Vyper04Compiler(BaseVyperCompiler):
         # You always import via module or package name.
         return {}
 
+    def get_settings(
+        self,
+        version: Version,
+        source_paths: Iterable[Path],
+        compiler_data: dict,
+        project: Optional[ProjectManager] = None,
+    ) -> dict:
+        pm = project or self.local_project
+
+        enable_decimals = self.api.get_config(project=pm).enable_decimals
+        if enable_decimals is None:
+            enable_decimals = False
+
+        settings = super().get_settings(version, source_paths, compiler_data, project=pm)
+        for settings_set in settings.values():
+            settings_set["enable_decimals"] = enable_decimals
+
+        return settings
+
     def _get_sources_dictionary(
         self, source_ids: Iterable[str], project: Optional[ProjectManager] = None, **kwargs
     ) -> dict[str, dict]:

--- a/ape_vyper/config.py
+++ b/ape_vyper/config.py
@@ -32,6 +32,13 @@ class VyperConfig(PluginConfig):
 
     """
 
+    enable_decimals: Optional[bool] = None
+    """
+    On Vyper 0.4, to use decimal types, you must enable it.
+    Defaults to ``None`` to avoid misleading that ``False``
+    means you cannot use decimals on a lower version.
+    """
+
     @field_validator("version", mode="before")
     def validate_version(cls, value):
         return pragma_str_to_specifier_set(value) if isinstance(value, str) else value

--- a/ape_vyper/flattener.py
+++ b/ape_vyper/flattener.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from ape.logging import logger
 from ape.managers import ProjectManager
-from ape.utils import ManagerAccessMixin
+from ape.utils import ManagerAccessMixin, get_relative_path
 from ethpm_types.source import Content
 
 from ape_vyper._utils import get_version_pragma_spec
@@ -65,7 +65,10 @@ class Flattener(ManagerAccessMixin):
         flattened_modules = ""
         modules_prefixes: set[str] = set()
 
-        for import_path in sorted(imports):
+        # Source by source ID for greater consistency..
+        for import_path in sorted(
+            imports, key=lambda p: f"{get_relative_path(p.absolute(), pm.path)}"
+        ):
             import_info = imports[import_path]
 
             # Vyper imported interface names come from their file names

--- a/tests/contracts/passing_contracts/subdir/zero_four_in_subdir.vy
+++ b/tests/contracts/passing_contracts/subdir/zero_four_in_subdir.vy
@@ -1,5 +1,5 @@
 # Show we can import from the root of the project w/o needing relative imports
-from contracts.passing_contracts import zero_four_module as zero_four_module
+from tests.contracts.passing_contracts import zero_four_module as zero_four_module
 
 @external
 def callModuleFunctionFromSubdir(role: bytes32) -> bool:

--- a/tests/contracts/passing_contracts/use_iface.vy
+++ b/tests/contracts/passing_contracts/use_iface.vy
@@ -10,7 +10,7 @@ import exampledependency.Dependency as Dep
 from .interfaces import IFace2 as IFace2
 
 # Also use IFaceNested to show we can use nested interfaces.
-from contracts.passing_contracts.interfaces.nested import IFaceNested as IFaceNested
+from tests.contracts.passing_contracts.interfaces.nested import IFaceNested as IFaceNested
 
 
 @external

--- a/tests/functional/test_compiler.py
+++ b/tests/functional/test_compiler.py
@@ -56,28 +56,6 @@ interface IFaceZeroFour:
     def implementThisPlease(role: bytes32) -> bool: view
 
 
-# Showing importing interface from module.
-interface Ballot:
-    def delegated(addr: address) -> bool: view
-
-@internal
-def moduleMethod2() -> bool:
-    return True
-
-
-# This source is also imported from `zero_four.py` to test
-# multiple imports across sources during flattening.
-
-@internal
-def moduleMethod() -> bool:
-    return True
-
-
-@external
-def callModule2FunctionFromAnotherSource(role: bytes32) -> bool:
-    return self.moduleMethod2()
-
-
 # @dev Returns the address of the current owner.
 # @notice If you declare a variable as `public`,
 # Vyper automatically generates an `external`
@@ -153,6 +131,28 @@ def _transfer_ownership(new_owner: address):
     old_owner: address = self.owner
     self.owner = new_owner
     log OwnershipTransferred(old_owner, new_owner)
+
+
+# Showing importing interface from module.
+interface Ballot:
+    def delegated(addr: address) -> bool: view
+
+@internal
+def moduleMethod2() -> bool:
+    return True
+
+
+# This source is also imported from `zero_four.py` to test
+# multiple imports across sources during flattening.
+
+@internal
+def moduleMethod() -> bool:
+    return True
+
+
+@external
+def callModule2FunctionFromAnotherSource(role: bytes32) -> bool:
+    return self.moduleMethod2()
 
 
 implements: IFaceZeroFour


### PR DESCRIPTION
### What I did

to use decimals in Vyper 0.4, you must add the setting `enable_decimals`.

### How I did it

Add the setting for vyper-json

### How to verify it

```yaml
vyper:
  enable_decimals: true
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
