### PR TITLE
fix(config): enable decimals for Vyper 0.4

### DIFF
--- a/ape_vyper/ast.py
+++ b/ape_vyper/ast.py
@@ -2,6 +2,7 @@
 
 from ethpm_types import ABI, MethodABI
 from ethpm_types.abi import ABIType
+
 from vyper.ast import parse_to_ast  # type: ignore
 from vyper.ast.nodes import FunctionDef, Module, Name, Subscript  # type: ignore
 

--- a/ape_vyper/compiler/_versions/vyper_04.py
+++ b/ape_vyper/compiler/_versions/vyper_04.py
@@ -129,7 +129,7 @@ class Vyper04Compiler(BaseVyperCompiler):
                 "evm_version": self.get_evm_version(vyper_version),
                 "output_format": self.get_output_format(project=pm),
                 "additional_paths": [*getsitepackages()],
-                "enable_decimals": settings.get("enable_decimals", False),
+                "enable_decimals": settings_set.get("enable_decimals", False),
             }
 
             if self.api.package_version == vyper_version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
+skip = ["version.py"]
 
 [tool.mdformat]
 number = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
-skip = ["version.py"]
+# TODO: Figure out why `ast.py` doesn't work (or switch to ruff)
+skip = ["ast.py", "version.py"]
 
 [tool.mdformat]
 number = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ ALL_VERSIONS = (
     "0.3.9",
     "0.3.10",
     "0.4.0",
+    "0.4.1",
 )
 
 CONTRACT_VERSION_GEN_MAP = {

--- a/tests/functional/test_compiler.py
+++ b/tests/functional/test_compiler.py
@@ -30,7 +30,7 @@ from ..conftest import FAILING_BASE, FAILING_CONTRACT_NAMES, PASSING_CONTRACT_NA
 OLDER_VERSION_FROM_PRAGMA = Version("0.2.16")
 VERSION_37 = Version("0.3.7")
 VERSION_FROM_PRAGMA = Version("0.3.10")
-VERSION_04 = Version("0.4.0")
+VERSION_04 = Version("0.4.1")
 
 
 @pytest.fixture
@@ -853,7 +853,7 @@ def test_solc_json_format(compiler, projects_path):
     project = ape.Project(projects_path / "solc_json")
 
     expected_json = {
-        "compiler_version": "v0.4.0+commit.e9db8d9",
+        "compiler_version": "v0.4.1+commit.8a93dd27",
         "integrity": "31bec6a1a057f4d62545cb1aaf7ee960951b277d040efae56eefcc0baa0deaad",
         "language": "Vyper",
         "settings": {

--- a/tests/functional/test_compiler.py
+++ b/tests/functional/test_compiler.py
@@ -131,7 +131,7 @@ def _transfer_ownership(new_owner: address):
     \"\"\"
     old_owner: address = self.owner
     self.owner = new_owner
-    log OwnershipTransferred(old_owner, new_owner)
+    log OwnershipTransferred(previous_owner=old_owner, new_owner=new_owner)
 
 
 # Showing importing interface from module.
@@ -304,6 +304,7 @@ def test_get_version_map(project, compiler, all_versions):
     expected4 = {
         "contract_no_pragma.vy",
         "empty.vy",
+        "sub_reverts_041.vy",
         "zero_four.vy",
         "zero_four_module.vy",
         "zero_four_module_2.vy",
@@ -828,12 +829,11 @@ def test_get_compiler_settings(project, compiler):
     assert v4_version_used >= Version(
         "0.4.0"
     ), f"version={v4_version_used} full_data={vyper4_settings}"
-    assert vyper4_settings[v4_version_used]["gas%shanghai"]["enable_decimals"] is True
-    assert vyper4_settings[v4_version_used]["gas%shanghai"]["optimize"] == "gas"
-    assert vyper4_settings[v4_version_used]["gas%shanghai"]["outputSelection"] == {
+    assert vyper4_settings[v4_version_used]["gas%none"]["enable_decimals"] is True
+    assert vyper4_settings[v4_version_used]["gas%none"]["optimize"] == "gas"
+    assert vyper4_settings[v4_version_used]["gas%none"]["outputSelection"] == {
         "tests/contracts/passing_contracts/zero_four.vy": ["*"]
     }
-    assert vyper4_settings[v4_version_used]["gas%shanghai"]["evmVersion"] == "shanghai"
 
 
 def test_compile_configured_output_format(project, compiler):

--- a/tests/functional/test_compiler.py
+++ b/tests/functional/test_compiler.py
@@ -857,7 +857,6 @@ def test_solc_json_format(compiler, projects_path):
         "integrity": "31bec6a1a057f4d62545cb1aaf7ee960951b277d040efae56eefcc0baa0deaad",
         "language": "Vyper",
         "settings": {
-            "evmVersion": "shanghai",
             "outputSelection": {
                 "contracts/ContractForSolcJSON.vy": [
                     "*",


### PR DESCRIPTION
### What I did

Noticed we were using `settings` and not `settings_set` to pull the decimals kwarg from the settings profile

fixes: #152

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
