### PR TITLE
bump: vyper upper bound to <0.6 to allow 0.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "ethpm-types",  # Use same version as eth-ape
     "tqdm",  # Use same version as eth-ape
     "vvm>=0.2.0,<0.4",
-    "vyper>=0.3.7,<0.5",
+    "vyper>=0.3.7,<0.6",
 ]
 
 [project.entry-points."ape_cli_subcommands"]


### PR DESCRIPTION
## Summary

Bump the `vyper` upper bound from `<0.5` to `<0.6` so users can install Vyper 0.5.x (currently `0.5.0a1` from master) into the same venv as `ape-vyper` without `pip` silently downgrading them.

```diff
-    "vyper>=0.3.7,<0.5",
+    "vyper>=0.3.7,<0.6",
```

## Why

Surfaced while debugging [foundry-rs/foundry#14643](https://github.com/foundry-rs/foundry/issues/14643). [snekmate](https://github.com/pcaversaccio/snekmate)'s CI installs `vyper@master` (0.5.0a1) and then runs the `ApeWorX/github-action`, which performs `ape plugins install --upgrade .`. With the current `<0.5` cap, `pip` resolves the upgrade down to the latest stable in range (0.4.3) and replaces the user's 0.5.0a1 binary in-place. Subsequent `forge` invocations then call the downgraded binary, which rightly rejects the project's `# pragma version ~=0.5.0a1` pragma.

Reproduction (Python 3.14, fresh venv):

```
$ pip install git+https://github.com/vyperlang/vyper.git@master eth-ape
$ vyper --version
0.5.0a1+commit.7d73c468
$ ape plugins install --upgrade vyper
$ vyper --version
0.4.3+commit.bff19ea2          # ← downgraded
```

After bumping the cap to `<0.6`:

```
$ pip install git+https://github.com/vyperlang/vyper.git@master eth-ape
$ pip install --upgrade /path/to/patched-ape-vyper
$ vyper --version
0.5.0a1+commit.7d73c468        # ← preserved
$ ape compile                  # SUCCESS, uses Vyper 0.5.0a1
$ forge build                  # Compiler run successful
```

## Compatibility

An alternative is to keep the cap at `<0.5` but add `--pre` plumbing or PEP 440 specifier handling to the plugin install command.
