### PR TITLE
fix: detect modern vyper version pragmas

### DIFF
--- a/ape_vyper/_utils.py
+++ b/ape_vyper/_utils.py
@@ -2,7 +2,7 @@ import os
 import re
 import subprocess
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -15,14 +15,16 @@ from ape.utils import get_relative_path
 from eth_utils import is_0x_prefixed
 from ethpm_types import ASTNode, PCMap, SourceMapItem
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import Version
+from semantic_version import NpmSpec  # type: ignore[import-untyped]
+from semantic_version import Version as NpmVersion  # type: ignore[import-untyped]
 from vvm.exceptions import UnknownOption, UnknownValue  # type: ignore
 
-from ape_vyper.exceptions import RuntimeErrorType, VyperError, VyperInstallError
+from ape_vyper.exceptions import RuntimeErrorType, VyperCompileError, VyperError, VyperInstallError
 
 if TYPE_CHECKING:
     from ape.types.trace import SourceTraceback
     from ethpm_types.source import Function
-    from packaging.version import Version
 
 Optimization = str | bool
 EVM_VERSION_DEFAULT = {
@@ -82,7 +84,82 @@ def install_vyper(version: "Version"):
                 ) from err
 
 
-def get_version_pragma_spec(source: str | Path) -> SpecifierSet | None:
+VERSION_PRAGMA_PATTERN = re.compile(
+    r"(?:\n|^)\s*#\s*(?P<style>@version|pragma\s+version)\s*(?P<version>[^\n]*)"
+)
+# Vyper 0.3.10 switched version pragma matching from NpmSpec to SpecifierSet.
+VYPER_PEP440_PRAGMA_START_VERSION = Version("0.3.10")
+
+
+def _as_pep440_spec(pragma_str: str) -> str:
+    pragma_str = pragma_str.replace("^", "~=")
+    if pragma_str and pragma_str[0].isnumeric():
+        return f"=={pragma_str}"
+
+    return pragma_str
+
+
+def _as_npm_version(version: Version) -> NpmVersion:
+    version_str = str(version)
+    version_str = re.sub(r"(?<=\d)a(?=\d)", "-alpha.", version_str)
+    version_str = re.sub(r"(?<=\d)b(?=\d)", "-beta.", version_str)
+    version_str = re.sub(r"(?<=\d)rc(?=\d)", "-rc.", version_str)
+    return NpmVersion(version_str)
+
+
+class VyperVersionSpecifier:
+    def __init__(self, pragma_str: str, style: str, source_path: Path | None = None):
+        self.pragma_str = pragma_str
+        self.style = style
+        self.source_path = source_path
+        self._npm_spec: NpmSpec | None = None
+        self._pep440_spec: SpecifierSet | None = None
+
+        try:
+            self._npm_spec = NpmSpec(pragma_str)
+        except ValueError:
+            pass
+
+        try:
+            self._pep440_spec = SpecifierSet(_as_pep440_spec(pragma_str))
+        except InvalidSpecifier:
+            pass
+
+        if not self._npm_spec and not self._pep440_spec:
+            raise self._error()
+
+        if self.is_modern_pragma and not self._pep440_spec:
+            raise self._error()
+
+    @property
+    def is_modern_pragma(self) -> bool:
+        return self.style.startswith("pragma")
+
+    def match(self, version: Version) -> bool:
+        if version >= VYPER_PEP440_PRAGMA_START_VERSION:
+            return bool(self._pep440_spec and self._pep440_spec.contains(version, prereleases=True))
+
+        return not self.is_modern_pragma and bool(
+            self._npm_spec and self._npm_spec.match(_as_npm_version(version))
+        )
+
+    def contains(self, version: str | Version) -> bool:
+        return self.match(version if isinstance(version, Version) else Version(version))
+
+    def filter(self, versions: Iterable[Version]) -> Iterator[Version]:
+        return (version for version in versions if self.match(version))
+
+    def _error(self) -> VyperCompileError:
+        source_label = f" in '{self.source_path}'" if self.source_path else ""
+        return VyperCompileError(
+            f"Invalid Vyper version pragma{source_label}: '{self.pragma_str}'."
+        )
+
+    def __str__(self) -> str:
+        return self.pragma_str
+
+
+def get_version_pragma_spec(source: str | Path) -> VyperVersionSpecifier | None:
     """
     Extracts version pragma information from Vyper source code.
 
@@ -90,26 +167,23 @@ def get_version_pragma_spec(source: str | Path) -> SpecifierSet | None:
         source (str): Vyper source code
 
     Returns:
-        ``packaging.specifiers.SpecifierSet``, or None if no valid pragma is found.
+        ``VyperVersionSpecifier``, or None if no pragma is found.
     """
-    _version_pragma_patterns: tuple[str, str] = (
-        r"(?:\n|^)\s*#\s*@version\s*([^\n]*)",
-        r"(?:\n|^)\s*#\s*pragma\s+version\s*([^\n]*)",
-    )
-
     source_str = source if isinstance(source, str) else source.read_text(encoding="utf8")
-    for pattern in _version_pragma_patterns:
-        for match in re.finditer(pattern, source_str):
-            raw_pragma = match.groups()[0]
-            pragma_str = " ".join(raw_pragma.split()).replace("^", "~=")
-            if pragma_str and pragma_str[0].isnumeric():
-                pragma_str = f"=={pragma_str}"
+    source_path = source if isinstance(source, Path) else None
+    if pragma_match := next(re.finditer(VERSION_PRAGMA_PATTERN, source_str), None):
+        raw_pragma = pragma_match.group("version")
+        pragma_str = " ".join(raw_pragma.split())
+        if not pragma_str:
+            source_label = f" in '{source_path}'" if source_path else ""
+            raise VyperCompileError(f"Invalid Vyper version pragma{source_label}: missing version.")
 
-            try:
-                return SpecifierSet(pragma_str)
-            except InvalidSpecifier:
-                logger.warning(f"Invalid pragma spec: '{raw_pragma}'. Trying latest.")
-                return None
+        return VyperVersionSpecifier(
+            pragma_str,
+            style=" ".join(pragma_match.group("style").split()),
+            source_path=source_path,
+        )
+
     return None
 
 
@@ -260,7 +334,9 @@ def lookup_source_from_site_packages(
     return None
 
 
-def safe_append(data: dict, version: "Version | SpecifierSet", paths: Path | set):
+def safe_append(
+    data: dict, version: "Version | SpecifierSet | VyperVersionSpecifier", paths: Path | set
+):
     if isinstance(paths, Path):
         paths = {paths}
     if version in data:

--- a/ape_vyper/compiler/api.py
+++ b/ape_vyper/compiler/api.py
@@ -17,7 +17,13 @@ from ape.utils._github import _GithubClient
 from ethpm_types.source import Compiler, Content, ContractSource
 from packaging.version import Version
 
-from ape_vyper._utils import FileType, get_version_pragma_spec, install_vyper, safe_append
+from ape_vyper._utils import (
+    FileType,
+    VyperVersionSpecifier,
+    get_version_pragma_spec,
+    install_vyper,
+    safe_append,
+)
 from ape_vyper.compiler._versions import (
     BaseVyperCompiler,
     Vyper02Compiler,
@@ -396,7 +402,7 @@ class VyperCompiler(CompilerAPI):
         self.compiler_settings = {**self.compiler_settings}
         config = config or self.get_config(pm)
         version_map: dict[Version, set[Path]] = {}
-        source_path_by_version_spec: dict[SpecifierSet, set[Path]] = {}
+        source_path_by_version_spec: dict[SpecifierSet | VyperVersionSpecifier, set[Path]] = {}
         source_paths_without_pragma = set()
 
         # Sort contract_filepaths to promote consistent, reproduce-able behavior

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
     "eth-ape>=0.8.25,<0.9",
     "ethpm-types",  # Use same version as eth-ape
+    "semantic-version>=2.10,<3",
     "tqdm",  # Use same version as eth-ape
     "vvm>=0.2.0,<0.4",
     "vyper>=0.3.7,<0.6",

--- a/tests/functional/test_compiler.py
+++ b/tests/functional/test_compiler.py
@@ -12,7 +12,7 @@ from ethpm_types import ContractType
 from packaging.version import Version
 from vvm.exceptions import VyperError  # type: ignore
 
-from ape_vyper._utils import EVM_VERSION_DEFAULT
+from ape_vyper._utils import EVM_VERSION_DEFAULT, get_version_pragma_spec
 from ape_vyper.exceptions import (
     FallbackNotDefinedError,
     IntegerOverflowError,
@@ -29,6 +29,30 @@ from ..conftest import FAILING_BASE, FAILING_CONTRACT_NAMES, PASSING_CONTRACT_NA
 OLDER_VERSION_FROM_PRAGMA = Version("0.2.16")
 VERSION_37 = Version("0.3.7")
 VERSION_FROM_PRAGMA = Version("0.3.10")
+
+VYPER_PEP440_VALID_PRAGMAS = (
+    "0.3.10",
+    ">0.3.9",
+    "^0.3.10",
+    "<=1.0.0,>=0.3.10",
+    "~=0.3.10",
+)
+VYPER_PEP440_INVALID_PRAGMAS = (
+    "0.3.9",
+    ">1.0.0",
+    "^0.4.0",
+    "0.2",
+    "1",
+)
+VYPER_PEP440_INVALID_SYNTAX_PRAGMAS = (
+    "<=0.3.9 >=1.1.1",
+    "1.0.0 - 2.0.0",
+    "~1.0.0",
+    "1.x",
+    "0.2.x",
+    "0.2.0 || 0.1.3",
+    "abc",
+)
 
 
 @pytest.fixture
@@ -239,6 +263,81 @@ def test_install_failure(compiler):
     path = FAILING_BASE / "contract_unknown_pragma.vy"
     with pytest.raises(VyperInstallError, match="No available version to install."):
         list(compiler.compile((path,), project=failing_project))
+
+
+@pytest.mark.parametrize(
+    "source,version,expected",
+    (
+        ("# @version ^0.3.8", VERSION_FROM_PRAGMA, True),
+        ("# @version ~=0.3.10", Version("0.3.10"), True),
+        ("# @version >=0.3.8 <0.4.0", Version("0.3.9"), True),
+        ("# @version >=0.3.8 <0.4.0", VERSION_FROM_PRAGMA, False),
+        ("# pragma version ^0.3.10", VERSION_FROM_PRAGMA, True),
+        ("# pragma version ^0.3.8", Version("0.3.9"), False),
+        ("#pragma version >=0.4.2", Version("0.4.2"), True),
+    ),
+)
+def test_get_version_pragma_spec(source, version, expected):
+    pragma_spec = get_version_pragma_spec(source)
+    assert pragma_spec is not None
+    assert pragma_spec.match(version) is expected
+
+
+def test_get_version_pragma_spec_no_pragma():
+    assert get_version_pragma_spec("# dev: no compiler version here") is None
+
+
+def test_get_version_pragma_spec_invalid():
+    with pytest.raises(
+        VyperCompileError, match="Invalid Vyper version pragma.*definitely-not-a-spec"
+    ):
+        get_version_pragma_spec("# pragma version definitely-not-a-spec")
+
+
+def test_get_version_pragma_spec_invalid_modern_grammar():
+    with pytest.raises(VyperCompileError, match="Invalid Vyper version pragma.*>=0.3.8"):
+        get_version_pragma_spec("# pragma version >=0.3.8 <0.4.0")
+
+
+@pytest.mark.parametrize("pragma_string", VYPER_PEP440_VALID_PRAGMAS)
+def test_get_version_pragma_spec_vyper_pep440_valid_versions(pragma_string):
+    pragma_spec = get_version_pragma_spec(f"# pragma version {pragma_string}")
+    assert pragma_spec is not None
+    assert pragma_spec.match(VERSION_FROM_PRAGMA)
+
+
+@pytest.mark.parametrize("pragma_string", VYPER_PEP440_INVALID_PRAGMAS)
+def test_get_version_pragma_spec_vyper_pep440_invalid_versions(pragma_string):
+    pragma_spec = get_version_pragma_spec(f"# pragma version {pragma_string}")
+    assert pragma_spec is not None
+    assert not pragma_spec.match(VERSION_FROM_PRAGMA)
+
+
+@pytest.mark.parametrize("pragma_string", VYPER_PEP440_INVALID_SYNTAX_PRAGMAS)
+def test_get_version_pragma_spec_vyper_pep440_invalid_syntax(pragma_string):
+    with pytest.raises(VyperCompileError, match="Invalid Vyper version pragma"):
+        get_version_pragma_spec(f"# pragma version {pragma_string}")
+
+
+def test_get_version_map_modern_pragma(tmp_path, compiler, monkeypatch):
+    versions = [Version("0.3.9"), VERSION_FROM_PRAGMA]
+    monkeypatch.setattr(type(compiler), "installed_versions", property(lambda _: versions))
+    contracts = tmp_path / "contracts"
+    contracts.mkdir()
+    path = contracts / "modern_pragma.vy"
+    path.write_text("# pragma version ^0.3.8\n", encoding="utf8")
+    actual = compiler.get_version_map([path], project=ape.Project(tmp_path))
+    assert actual == {VERSION_FROM_PRAGMA: {path}}
+
+
+def test_get_version_map_invalid_pragma(tmp_path, compiler):
+    project = ape.Project(tmp_path)
+    contracts = tmp_path / "contracts"
+    contracts.mkdir()
+    path = contracts / "invalid_pragma.vy"
+    path.write_text("# pragma version definitely-not-a-spec\n", encoding="utf8")
+    with pytest.raises(VyperCompileError, match=f"Invalid Vyper version pragma.*{path}"):
+        compiler.get_version_map([path], project=project)
 
 
 def test_get_version_map(project, compiler, all_versions):


### PR DESCRIPTION
## Motivation

Current Vyper accepts source compiler constraints in both legacy `# @version ...` comments and modern `# pragma version ...` comments. `ape-vyper` only recognized the legacy spelling, so modern Vyper sources could be grouped with no-pragma sources and compiled with the wrong selected compiler before Vyper itself validated the source constraint.

Vyper also changed the version-pragma grammar across releases: `v0.3.9` and earlier use npm-style semantic version specs, while `v0.3.10` and newer use `packaging.specifiers.SpecifierSet`-style rules after caret translation. Ape needs to use the rules for each candidate compiler version, otherwise compiler selection can accept or reject a pragma differently than Vyper would.

Malformed present pragmas now fail early as `VyperCompileError` instead of being treated as missing pragmas.

## Code References

- Vyper validates version pragmas in [`validate_version_pragma()`](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/vyper/ast/pre_parser.py#L17-L44).
- Vyper parses modern [`# pragma version`](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/vyper/ast/pre_parser.py#L47-L58).
- Vyper still accepts legacy [`# @version`](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/vyper/ast/pre_parser.py#L298-L308).
- Vyper keeps [`compiler_version`](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/vyper/compiler/settings.py#L132-L195) source-only, not a compiler input.
- Vyper tests cover [valid/invalid specs](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/tests/unit/ast/test_pre_parser.py#L17-L55), [file-specific errors](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/tests/unit/ast/test_pre_parser.py#L61-L75), [`#pragma version`](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/tests/unit/ast/test_pre_parser.py#L145-L148), and [import validation](https://github.com/vyperlang/vyper/blob/f7e23d3f3f1a6f843b49560d8c62945076f5a1d1/tests/unit/ast/test_pre_parser.py#L280-L284).
- Historical Vyper `v0.3.9` used [`NpmSpec`](https://github.com/vyperlang/vyper/blob/v0.3.9/vyper/ast/pre_parser.py#L1-L54); `v0.3.10` switched to [`SpecifierSet`](https://github.com/vyperlang/vyper/blob/v0.3.10/vyper/ast/pre_parser.py#L1-L38).

## Summary

- Recognize both `# @version ...` and `# pragma version ...`.
- Preserve whitespace tolerance for `#pragma version ...`.
- Match candidate compiler versions using Vyper's release-specific grammar: npm-style for `<0.3.10`, PEP 440-style for `>=0.3.10`.
- Add `semantic-version` for the legacy npm-style grammar.
- Raise a clear `VyperCompileError` when a present version pragma cannot be parsed.
- Add focused parser and version-map coverage, including cases adapted from Vyper's pre-parser tests.

## Tests

- `git diff --check`
- `uv run --group lint ruff check .`
- `uv run --group lint ruff format --check .`
- `uv run --group lint --group test mypy .`
- `uv run --python 3.11 --group test python -m py_compile ape_vyper/_utils.py ape_vyper/compiler/api.py tests/functional/test_compiler.py`
- `uv run --python 3.11 --group test pytest tests/functional/test_compiler.py -q -k "version_pragma_spec or version_map_modern_pragma or version_map_invalid_pragma"` (`29 passed, 102 deselected`)

Note: `uv run --python 3.11 --group test pytest tests/functional/test_compiler.py -q` was also attempted locally. The compile-heavy cases failed after `vvm.get_installable_vyper_versions()` hit the GitHub API rate limit, leaving no installable `0.4.x` compiler for the existing 0.4 fixtures. The focused parser/version-map coverage above passes.
