### PR TITLE
fix: remove vyper package

### DIFF
--- a/ape_vyper/flattener.py
+++ b/ape_vyper/flattener.py
@@ -6,7 +6,6 @@ from ape.logging import logger
 from ape.utils import ManagerAccessMixin, get_relative_path
 from ethpm_types.source import Content
 
-from ape_vyper.ast import source_to_abi
 from ape_vyper.interface import (
     extract_import_aliases,
     extract_imports,
@@ -122,6 +121,10 @@ class Flattener(ManagerAccessMixin):
                 else:
                     # Vyper <0.4 interface from folder other than interfaces/
                     # such as a .vyi file in the contracts folder.
+                    try:
+                        from ape_vyper.ast import source_to_abi
+                    except ImportError as err:
+                        raise UsageError("Must install `vyper` for this feature to work") from err
                     abis = source_to_abi(import_path.read_text(encoding="utf8"))
                     interfaces_source += generate_interface(abis, import_name)
 

--- a/ape_vyper/flattener.py
+++ b/ape_vyper/flattener.py
@@ -123,8 +123,10 @@ class Flattener(ManagerAccessMixin):
                     # such as a .vyi file in the contracts folder.
                     try:
                         from ape_vyper.ast import source_to_abi
+
                     except ImportError as err:
-                        raise UsageError("Must install `vyper` for this feature to work") from err
+                        raise RuntimeError("Must install `vyper` for this feature to work") from err
+
                     abis = source_to_abi(import_path.read_text(encoding="utf8"))
                     interfaces_source += generate_interface(abis, import_name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "semantic-version>=2.10,<3",
     "tqdm",  # Use same version as eth-ape
     "vvm>=0.2.0,<0.4",
-    "vyper>=0.3.7,<0.6",
 ]
 
 [project.entry-points."ape_cli_subcommands"]
@@ -48,6 +47,7 @@ test = [
     "pytest-cov",  # Coverage analyzer (also supported by plugin)
     "pytest-mock",  # Needed to mock certain CLI interactions
     "snekmate",  # Python package source for integration testing
+    "vyper>=0.3.7",  # For testing flattener
 ]
 lint = [
     "ruff>=0.14,<1",  # Auto-formatter and linter


### PR DESCRIPTION
### What I did

Noticed that #107 added `vyper` package into the mainline dependencies. We want to avoid specifying vyper as explicit dependency to allow arbitrary package install use with the plugin (for compiler development and ad-hoc use cases)

fixes: #165

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
