### PR TITLE
feat: compile .vyi interfaces as types

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Import the voting contract types like this:
 import voting.ballot as ballot
 ```
 
+Standalone Vyper interface files `.vyi` outside the `interfaces` directory compile into ABI-only ContractTypes. These artifacts are not deployable, but they can be used from Ape scripts to interact with already deployed contracts. For example, `contracts/IFace.vyi` interface can be used in a script:
+
+```python
+from ape import project
+
+iface = project.IFace.at("0x...")
+iface.some_method()
+```
+
 ### Decimals
 
 To use decimals on Vyper 0.4, use the following config:

--- a/ape_vyper/compiler/_versions/vyper_04.py
+++ b/ape_vyper/compiler/_versions/vyper_04.py
@@ -96,12 +96,31 @@ class Vyper04Compiler(BaseVyperCompiler):
     ) -> dict:
         pm = project or self.local_project
         return {
-            s: ["*"]
+            s: ["abi"] if get_full_extension(pm.path / s) == FileType.INTERFACE else ["*"]
             for s in selection
-            if ((pm.path / s).is_file())
-            and f"interfaces{os.path.sep}" not in s
-            and get_full_extension(pm.path / s) != FileType.INTERFACE
+            if ((pm.path / s).is_file()) and f"interfaces{os.path.sep}" not in s
         }
+
+    def _get_files_by_output_format(
+        self,
+        output_selection: dict[str, list[str]],
+        source_ids: Iterable[str],
+        project: "ProjectManager | None" = None,
+    ) -> dict[tuple[str, ...], list[Path]]:
+        pm = project or self.local_project
+        default_output_format = tuple(self.get_output_format(project=pm))
+        files_by_output_format: dict[tuple[str, ...], list[Path]] = {}
+
+        for source_id in source_ids:
+            source_output_format = output_selection.get(source_id, ["*"])
+            output_format = (
+                default_output_format
+                if "*" in source_output_format
+                else tuple(source_output_format)
+            )
+            files_by_output_format.setdefault(output_format, []).append(Path(source_id))
+
+        return files_by_output_format
 
     def compile(
         self,
@@ -126,7 +145,6 @@ class Vyper04Compiler(BaseVyperCompiler):
 
             comp_kwargs = {
                 "evm_version": self.get_evm_version(vyper_version),
-                "output_format": self.get_output_format(project=pm),
                 "enable_decimals": settings_set.get("enable_decimals", False),
             }
 
@@ -139,30 +157,42 @@ class Vyper04Compiler(BaseVyperCompiler):
             else:
                 binary = get_executable(version=vyper_version)
 
-            files = [Path(p) for p in src_dict]
-
-            if "solc_json" in comp_kwargs.get("output_format", []):
-                # 'solc_json' output format does not work with other formats.
-                # So, we handle it separately.
-                comp_kwargs["output_format"] = [
-                    f for f in comp_kwargs["output_format"] if f != "solc_json"
-                ]
-                solc_json_comp_kwargs = {
-                    k: v for k, v in comp_kwargs.items() if k != "output_format"
-                }
-                solc_json_comp_kwargs["output_format"] = ["solc_json"]
-                try:
-                    result = compile_files(binary, files, pm.path, **solc_json_comp_kwargs)
-                except VyperError as err:
-                    raise VyperCompileError(err) from err
-
-                for source_id, output_items in result.items():
-                    self._output_solc_json(source_id, output_items["solc_json"], project=pm)
+            files_by_output_format = self._get_files_by_output_format(
+                output_selection,
+                src_dict,
+                project=pm,
+            )
 
             result = {}
             with pm.within_project_path():
                 try:
-                    result = compile_files(binary, files, pm.path, **comp_kwargs)
+                    for output_format, files in files_by_output_format.items():
+                        compile_kwargs = {
+                            **comp_kwargs,
+                            "output_format": list(output_format),
+                        }
+
+                        if "solc_json" in compile_kwargs["output_format"]:
+                            # 'solc_json' output format does not work with other formats.
+                            # So, we handle it separately.
+                            compile_kwargs["output_format"] = [
+                                f for f in compile_kwargs["output_format"] if f != "solc_json"
+                            ]
+                            solc_json_result = compile_files(
+                                binary,
+                                files,
+                                pm.path,
+                                output_format=["solc_json"],
+                                **comp_kwargs,
+                            )
+
+                            for source_id, output_items in solc_json_result.items():
+                                self._output_solc_json(
+                                    source_id, output_items["solc_json"], project=pm
+                                )
+
+                        result.update(compile_files(binary, files, pm.path, **compile_kwargs))
+
                 except VyperError as err:
                     raise VyperCompileError(err) from err
 

--- a/tests/contracts/passing_contracts/iface_abi.vyi
+++ b/tests/contracts/passing_contracts/iface_abi.vyi
@@ -1,0 +1,6 @@
+# pragma version >=0.4.1
+
+@external
+@view
+def read_stuff() -> uint256:
+    ...

--- a/tests/functional/test_compiler.py
+++ b/tests/functional/test_compiler.py
@@ -258,6 +258,34 @@ def test_compile_zero_four(compiler, project):
     assert "zero_four_in_subdir" in result
 
 
+def test_compile_standalone_vyi_as_abi_contract_type(project, compiler):
+    path = project.contracts_folder / "iface_abi.vyi"
+    contract_types = {ct.name: ct for ct in compiler.compile((path,), project=project)}
+
+    assert set(contract_types) == {"iface_abi"}
+
+    contract_type = contract_types["iface_abi"]
+    assert contract_type.source_id == "tests/contracts/passing_contracts/iface_abi.vyi"
+    assert contract_type.deployment_bytecode.bytecode is None
+    assert contract_type.runtime_bytecode.bytecode is None
+
+    abi = contract_type.abi
+    assert len(abi) == 1
+    assert abi[0].type == "function"
+    assert abi[0].name == "read_stuff"
+    assert abi[0].stateMutability == "view"
+    assert abi[0].inputs == []
+    assert [o.type for o in abi[0].outputs] == ["uint256"]
+
+
+def test_load_contracts_includes_standalone_vyi(project):
+    path = project.contracts_folder / "iface_abi.vyi"
+    contracts = project.load_contracts(path, use_cache=False)
+
+    assert "iface_abi" in contracts
+    assert contracts["iface_abi"].contract_type.abi[0].name == "read_stuff"
+
+
 def test_install_failure(compiler):
     failing_project = ape.Project(FAILING_BASE)
     path = FAILING_BASE / "contract_unknown_pragma.vy"


### PR DESCRIPTION
### What I did

Added support for compiling standalone `.vyi` interface files into ABI-only contract types so they can be used by ape scripts. This is similar to how JSON abi interfaces are handled.

fixes: #134 

### How I did it

- Removed previous filter for interface files for the Vyper 0.4 output selection.
- Set custom output selection of ["abi"] for interface files
- Run a separate vyper -f abi on interface files

NOTE: Keeping files under `interfaces/` import only as before and not exposed to ape scripts.

### How to verify it

Added regression coverage:

```bash
uv run pytest tests/functional/test_compiler.py -k "standalone_vyi"
```

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] Change is covered in tests
- [x] Documentation is complete
